### PR TITLE
Add WECAR scraping fallback and tests

### DIFF
--- a/src/routes/market_analysis.py
+++ b/src/routes/market_analysis.py
@@ -100,7 +100,20 @@ def fetch_wecar_data_for_month(target_date):
             return data
         except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
             logging.warning(f"Failed to fetch data from {url}. Reason: {e}")
-    return {"error": "missing", "attempted": urls}
+
+    # Attempt scraping when summary.json is missing
+    attempted = list(urls)
+    try:
+        from src.services import wecar_scraper
+        scraped = wecar_scraper.scrape_month(target_date)
+        scraped['source'] = 'WECAR Live (scraped)'
+        scraped['period'] = target_date.strftime('%b %Y')
+        return scraped
+    except Exception as e:
+        page_url = f"{base_url}/{year}/{month_short}/"
+        attempted.append(page_url)
+        logging.warning(f"Scraping failed for {page_url}: {e}")
+    return {"error": "missing", "attempted": attempted}
 
 @cache_result()
 def fetch_latest_wecar_data():

--- a/src/services/wecar_scraper.py
+++ b/src/services/wecar_scraper.py
@@ -1,0 +1,94 @@
+import re
+import json
+from datetime import datetime
+from typing import List, Dict
+import requests
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://wecartech.com/wecfiles/stats_new"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+def _get(url: str) -> str:
+    resp = requests.get(url, headers=HEADERS, timeout=10)
+    resp.raise_for_status()
+    return resp.text
+
+def _parse_data_provider(js_text: str) -> List[Dict]:
+    match = re.search(r'dataProvider"\s*:\s*(\[[^\]]*\])', js_text, re.DOTALL)
+    if not match:
+        return []
+    data = match.group(1)
+    # remove trailing commas
+    data = re.sub(r",\s*([}\]])", r"\1", data)
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError:
+        return []
+
+def _find_month_entry(data: List[Dict], month_key: str) -> Dict:
+    for entry in data:
+        month = entry.get("month") or entry.get("category")
+        if isinstance(month, str) and month.lower().startswith(month_key):
+            return entry
+    return {}
+
+def scrape_month(target_date: datetime) -> Dict:
+    """Scrape WECAR stats page for the given month."""
+    year = target_date.year
+    month_dir = target_date.strftime("%b").lower()
+    page_url = f"{BASE_URL}/{year}/{month_dir}/"
+
+    # Fetch HTML page and gather JS references
+    html = _get(page_url)
+    soup = BeautifulSoup(html, "html.parser")
+    script_srcs = [s.get("src") for s in soup.find_all("script") if s.get("src")]
+
+    month_key = target_date.strftime("%b").lower()
+    year_key = str(year)
+
+    # Helper to fetch and parse a specific JS file if referenced
+    def get_data_from_js(name: str):
+        if name not in script_srcs:
+            return [], ""
+        js_text = _get(page_url + name)
+        return _parse_data_provider(js_text), js_text
+
+    # --- Average Price ---
+    avg_data, _ = get_data_from_js("js/avgprice.js")
+    avg_entry = _find_month_entry(avg_data, month_key)
+    avg_price = int(avg_entry.get(year_key, "0").replace(",", "")) if avg_entry else 0
+
+    # --- Total Sales ---
+    sales_data, _ = get_data_from_js("js/sales.js")
+    sales_entry = _find_month_entry(sales_data, month_key)
+    total_sales = int(sales_entry.get(year_key, "0").replace(",", "")) if sales_entry else 0
+
+    # --- New Listings and Available Listings ---
+    listings_data, listings_js = get_data_from_js("js/mamonth.js")
+    listings_entry = _find_month_entry(listings_data, month_key)
+    new_listings = int(listings_entry.get(year_key, "0").replace(",", "")) if listings_entry else 0
+    avail_match = re.search(r"Available Listings[^:]*:\s*([0-9,]+)", listings_js)
+    available_listings = int(avail_match.group(1).replace(",", "")) if avail_match else 0
+    months_of_supply = round(available_listings / total_sales, 2) if total_sales else 0
+
+    # --- Sales by Type (price range) ---
+    res_data, _ = get_data_from_js("js/resmonth.js")
+    sales_by_type = []
+    for entry in res_data:
+        name = entry.get("category")
+        sales_val = entry.get("units sold", "0")
+        try:
+            sales = int(str(sales_val).replace(",", ""))
+        except ValueError:
+            sales = 0
+        sales_by_type.append({"name": name, "sales": sales})
+
+    return {
+        "key_metrics": {
+            "average_price": avg_price,
+            "total_sales": total_sales,
+            "new_listings": new_listings,
+            "months_of_supply": months_of_supply,
+        },
+        "sales_by_type": sales_by_type,
+    }

--- a/tests/test_wecar_scraper.py
+++ b/tests/test_wecar_scraper.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from unittest.mock import patch, Mock
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.services import wecar_scraper
+
+
+def mocked_get_factory(responses):
+    def _mocked_get(url, headers=None, timeout=10):
+        text = responses.get(url)
+        if text is None:
+            raise AssertionError(f"Unexpected URL {url}")
+        response = Mock()
+        response.status_code = 200
+        response.text = text
+        response.raise_for_status = lambda: None
+        return response
+    return _mocked_get
+
+
+def test_scrape_month_parses_metrics_and_sales():
+    base = "https://wecartech.com/wecfiles/stats_new/2024/may/"
+    html = """
+    <html><body>
+    <script src="js/avgprice.js"></script>
+    <script src="js/sales.js"></script>
+    <script src="js/mamonth.js"></script>
+    <script src="js/resmonth.js"></script>
+    </body></html>
+    """
+    avg_js = """
+var chart = AmCharts.makeChart('avgprice', {
+  "dataProvider": [
+    {"month": "May", "2023": "100", "2024": "200",}
+  ]
+});
+"""
+    sales_js = """
+var chart = AmCharts.makeChart('sales', {
+  "dataProvider": [
+    {"month": "May", "2023": "10", "2024": "20",}
+  ]
+});
+"""
+    listings_js = """
+var chart = AmCharts.makeChart('mamonth', {
+  "dataProvider": [
+    {"month": "May", "2023": "30", "2024": "40",}
+  ],
+  "categoryAxis": {"title": "Available Listings (at time of report): 100"}
+});
+"""
+    res_js = """
+var chart = AmCharts.makeChart('resmonth', {
+  "dataProvider": [
+    {"category": "Single Family", "units sold": "15"},
+    {"category": "Townhouse/Condo", "units sold": "5"}
+  ]
+});
+"""
+
+    responses = {
+        base: html,
+        base + "js/avgprice.js": avg_js,
+        base + "js/sales.js": sales_js,
+        base + "js/mamonth.js": listings_js,
+        base + "js/resmonth.js": res_js,
+    }
+
+    with patch('requests.get', side_effect=mocked_get_factory(responses)):
+        result = wecar_scraper.scrape_month(datetime(2024, 5, 1))
+
+    assert result['key_metrics']['average_price'] == 200
+    assert result['key_metrics']['total_sales'] == 20
+    assert result['key_metrics']['new_listings'] == 40
+    assert result['key_metrics']['months_of_supply'] == 5.0
+    assert result['sales_by_type'] == [
+        {'name': 'Single Family', 'sales': 15},
+        {'name': 'Townhouse/Condo', 'sales': 5},
+    ]


### PR DESCRIPTION
## Summary
- add `wecar_scraper.scrape_month` to pull key metrics and sales by type from WECAR monthly pages
- fall back to scraping when `summary.json` is missing
- cover scraping logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c37bbef828832fa0571b6aba39b640