### PR TITLE
Add keyword analysis service and route

### DIFF
--- a/src/routes/seo_routes.py
+++ b/src/routes/seo_routes.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, request, jsonify
-# CORRECTED IMPORTS
 from services.seo_content_service import SEOContentService
 import logging
 
@@ -11,10 +10,16 @@ def analyze_keywords_route():
     data = request.get_json()
     if not data or 'keywords' not in data:
         return jsonify({"error": "Keywords are required"}), 400
-    
+
+    keywords = data['keywords']
+    if not isinstance(keywords, list):
+        return jsonify({"error": "Keywords must be a list"}), 400
+
     try:
-        result = seo_service.analyze_keywords(data['keywords'])
+        result = seo_service.analyze_keywords(keywords)
         return jsonify(result)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         logging.error(f"Error in keyword analysis: {e}")
         return jsonify({"error": "Failed to analyze keywords"}), 500

--- a/tests/test_seo_keywords.py
+++ b/tests/test_seo_keywords.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from flask import Flask
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from routes.seo_routes import seo_bp
+from services.seo_content_service import SEOContentService
+
+def create_app():
+    app = Flask(__name__)
+    app.register_blueprint(seo_bp, url_prefix="/seo")
+    return app
+
+
+def test_analyze_keywords_service():
+    service = SEOContentService()
+    result = service.analyze_keywords(["Home", "home", "Windsor"])
+    assert result["scores"]["home"] == 2
+    assert "windsor" in result["scores"]
+    assert "home" not in result.get("suggestions", [])
+
+
+def test_analyze_keywords_route_success():
+    app = create_app()
+    client = app.test_client()
+    resp = client.post("/seo/analyze-keywords", json={"keywords": ["Home", "Windsor"]})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["scores"]["home"] == 1
+
+
+def test_analyze_keywords_route_validation():
+    app = create_app()
+    client = app.test_client()
+    resp = client.post("/seo/analyze-keywords", json={"keywords": "home"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement keyword analysis in SEOContentService with normalization, frequency scoring, and suggestions
- expose analyze-keywords endpoint accepting keyword arrays and better error handling
- add tests covering service and route keyword analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45ac7d7ac832f8b29e3bacc37fff7