### PR TITLE
chore: centralize API client for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+node_modules/
+frontend/node_modules/
+frontend/dist/

--- a/frontend/src/AccountManager.jsx
+++ b/frontend/src/AccountManager.jsx
@@ -1,8 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
-
-// This is the variable that holds your backend URL
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from './api.js';
 
 // A simple, reusable button component for consistent styling
 const Button = ({ onClick, children, className, type = "button" }) => (
@@ -32,8 +29,7 @@ function AccountManager({ user }) {
   const fetchAccounts = async () => {
     setIsLoading(true);
     try {
-      // --- FIX: Added API_BASE_URL ---
-      const response = await axios.get(`${API_BASE_URL}/api/social-media/social-accounts`, {
+      const response = await api.get('/api/social-media/social-accounts', {
         params: { user_id: user.id }
       });
       setAccounts(response.data.accounts || []);
@@ -55,8 +51,7 @@ function AccountManager({ user }) {
     e.preventDefault();
     if (!accountName || !platform) return;
     try {
-      // --- FIX: Added API_BASE_URL ---
-      await axios.post(`${API_BASE_URL}/api/social-media/social-accounts`, {
+      await api.post('/api/social-media/social-accounts', {
         user_id: user.id,
         account_name: accountName,
         platform: platform,
@@ -71,8 +66,7 @@ function AccountManager({ user }) {
   const handleDeleteAccount = async (accountId) => {
     if (window.confirm("Are you sure you want to delete this account?")) {
       try {
-        // --- FIX: Added API_BASE_URL ---
-        await axios.delete(`${API_BASE_URL}/api/social-media/social-accounts/${accountId}`);
+        await api.delete(`/api/social-media/social-accounts/${accountId}`);
         fetchAccounts();
       } catch (err) {
         alert('Failed to delete account.');
@@ -91,8 +85,7 @@ function AccountManager({ user }) {
   const handleSaveEdit = async (e) => {
     e.preventDefault();
     try {
-      // --- FIX: Added API_BASE_URL ---
-      await axios.put(`${API_BASE_URL}/api/social-media/social-accounts/${editingAccount.id}`, {
+      await api.put(`/api/social-media/social-accounts/${editingAccount.id}`, {
         account_name: editName,
         platform: editPlatform,
       });

--- a/frontend/src/BrandVoiceManager.jsx
+++ b/frontend/src/BrandVoiceManager.jsx
@@ -2,9 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import styles from './BrandVoiceManager.module.css';
-import axios from 'axios';
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from './api.js';
 
 function BrandVoiceManager({ user }) {
   const [voices, setVoices] = useState([]);
@@ -19,8 +17,7 @@ function BrandVoiceManager({ user }) {
     setIsLoading(true);
     setError('');
     try {
-      // FIXED URL
-      const response = await axios.get(`${API_BASE_URL}/api/brand-voices/`, {
+      const response = await api.get('/api/brand-voices/', {
         params: { user_id: user.id }
       });
       setVoices(response.data.brand_voices || []);
@@ -41,8 +38,7 @@ function BrandVoiceManager({ user }) {
   const handleCreateVoice = async (e) => {
     e.preventDefault();
     try {
-      // FIXED URL
-      await axios.post(`${API_BASE_URL}/api/brand-voices/`, {
+      await api.post('/api/brand-voices/', {
         user_id: user.id,
         name: newVoiceName,
         description: newVoiceDesc,
@@ -61,8 +57,7 @@ function BrandVoiceManager({ user }) {
   const handleDeleteVoice = async (voiceId) => {
     if (window.confirm("Are you sure you want to delete this source content?")) {
       try {
-        // FIXED URL
-        await axios.delete(`${API_BASE_URL}/api/brand-voices/${voiceId}/`);
+        await api.delete(`/api/brand-voices/${voiceId}/`);
         fetchVoices();
       } catch (err) {
         console.error("Delete error:", err);

--- a/frontend/src/SocialMediaManager.jsx
+++ b/frontend/src/SocialMediaManager.jsx
@@ -1,8 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
-
-// This is the variable that holds your backend URL
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from './api.js';
 
 function SocialMediaManager({ user }) {
   const [posts, setPosts] = useState([]);
@@ -26,11 +23,10 @@ function SocialMediaManager({ user }) {
     setIsLoading(true);
     setError('');
     try {
-      // --- FIX: Added API_BASE_URL to all calls ---
       const [accountsRes, postsRes, brandVoicesRes] = await Promise.all([
-        axios.get(`${API_BASE_URL}/api/social-media/social-accounts`, { params: { user_id: user.id } }),
-        axios.get(`${API_BASE_URL}/api/social-media/posts`, { params: { user_id: user.id } }),
-        axios.get(`${API_BASE_URL}/api/brand-voices/`, { params: { user_id: user.id } })
+        api.get('/api/social-media/social-accounts', { params: { user_id: user.id } }),
+        api.get('/api/social-media/posts', { params: { user_id: user.id } }),
+        api.get('/api/brand-voices/', { params: { user_id: user.id } })
       ]);
       
       setAccounts(accountsRes.data.accounts || []);
@@ -66,8 +62,7 @@ function SocialMediaManager({ user }) {
     setIsGenerating(true);
     setError('');
     try {
-      // --- FIX: Added API_BASE_URL ---
-      const response = await axios.post(`${API_BASE_URL}/api/social-media/posts/generate`, {
+      const response = await api.post('/api/social-media/posts/generate', {
         user_id: user.id,
         topic: topic,
         brand_voice_id: selectedBrandVoice,
@@ -92,8 +87,7 @@ function SocialMediaManager({ user }) {
       return;
     }
     try {
-      // --- FIX: Added API_BASE_URL ---
-      await axios.post(`${API_BASE_URL}/api/social-media/posts`, {
+      await api.post('/api/social-media/posts', {
         account_id: selectedAccount,
         content: content,
         image_prompt: imagePrompt,

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- centralize axios API client to reuse base URL
- update React components to use shared API service
- ignore build and node modules artifacts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4624de9d8832f920dc978e75d189f