### PR TITLE
Handle missing performance insights

### DIFF
--- a/src/routes/social_media.py
+++ b/src/routes/social_media.py
@@ -69,9 +69,19 @@ def generate_ai_post():
     brand_voice = BrandVoice.query.filter_by(id=brand_voice_id, user_id=user_id).first()
     if not brand_voice: return jsonify({"error": "BrandVoice not found"}), 404
     insights = learning_algorithm_service.get_content_recommendations()
+    if not insights or "error" in insights:
+        return (
+            jsonify({"error": "Not enough performance data to generate recommendations."}),
+            503,
+        )
     try:
-        generated_data = ai_content_service.generate_optimized_post(topic=topic, brand_voice_example=brand_voice.post_example, performance_insights=insights)
-        if "error" in generated_data: return jsonify({"error": f"AI generation failed: {generated_data['error']}"}), 500
+        generated_data = ai_content_service.generate_optimized_post(
+            topic=topic,
+            brand_voice_example=brand_voice.post_example,
+            performance_insights=insights,
+        )
+        if "error" in generated_data:
+            return jsonify({"error": f"AI generation failed: {generated_data['error']}"}), 500
         return jsonify(generated_data), 200
     except Exception as e:
         logging.error(f"Error during AI post generation: {str(e)}")


### PR DESCRIPTION
## Summary
- Return 503 when learning algorithm service lacks insights to generate content
- Only call AI content service when performance insights are available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cb9745d4832fad1f88df0574b709