### PR TITLE
Replace print with logging in AI content service

### DIFF
--- a/src/services/ai_content_service.py
+++ b/src/services/ai_content_service.py
@@ -2,10 +2,14 @@
 
 import os
 import json
+import logging
 import openai
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
+
 
 class AIContentService:
     def __init__(self):
@@ -63,7 +67,7 @@ class AIContentService:
             return json.loads(response.choices[0].message.content)
 
         except Exception as e:
-            print(f"Error in AI content generation: {e}")
+            logger.error("Error in AI content generation: %s", e)
             return {"error": str(e)}
 
 ai_content_service = AIContentService()


### PR DESCRIPTION
## Summary
- use logging to report AI content generation failures

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cb90dfec832fb8a8167970a1a5cc