### PR TITLE
Fix logging service and social media route syntax

### DIFF
--- a/src/routes/social_media.py
+++ b/src/routes/social_media.py
@@ -135,4 +135,12 @@ def approve_post(post_id):
 def generate_image():
     data = request.get_json()
     if "prompt" not in data: return jsonify({"error": "Prompt is required"}), 400
-    return jsonify({"message": "Image generation not fully implemented.", "image_url": "https://via.placeholder.com/1080"} ), 501
+    return (
+        jsonify(
+            {
+                "message": "Image generation not fully implemented.",
+                "image_url": "https://via.placeholder.com/1080",
+            }
+        ),
+        501,
+    )

--- a/src/services/ai_content_service.py
+++ b/src/services/ai_content_service.py
@@ -2,11 +2,9 @@
 
 import os
 import json
- codex/update-ai_content_service-to-use-logging
 import logging
-
 import time
- main
+
 import openai
 from dotenv import load_dotenv
 
@@ -22,7 +20,13 @@ class AIContentService:
             raise ValueError("OPENAI_API_KEY environment variable not set.")
         openai.api_key = self.api_key
 
-    def generate_optimized_post(self, topic: str, brand_voice_example: str, performance_insights: dict) -> dict:
+    def generate_optimized_post(
+        self,
+        topic: str,
+        brand_voice_example: str,
+        performance_insights: dict,
+    ) -> dict:
+        """Generate an optimized social media post using OpenAI."""
         if not topic or not brand_voice_example:
             raise ValueError("Topic and brand voice example cannot be empty.")
 
@@ -66,27 +70,21 @@ class AIContentService:
                     response_format={"type": "json_object"},
                     messages=[
                         {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt}
+                        {"role": "user", "content": user_prompt},
                     ],
                     timeout=30,
                 )
                 return json.loads(response.choices[0].message.content)
             except Exception as e:
                 last_exception = e
-                print(f"Attempt {attempt + 1} failed: {e}")
+                logger.warning("Attempt %d failed: %s", attempt + 1, e)
                 if attempt < 2:
                     time.sleep(2 ** attempt)
 
- codex/update-ai_content_service-to-use-logging
-            return json.loads(response.choices[0].message.content)
+        logger.error(
+            "Failed to generate content after 3 attempts: %s", last_exception
+        )
+        return {"error": str(last_exception)}
 
-        except Exception as e:
-            logger.error("Error in AI content generation: %s", e)
-            return {"error": str(e)}
-
-        error_message = f"Failed to generate content after 3 attempts: {last_exception}"
-        print(error_message)
-        return {"error": error_message}
- main
 
 ai_content_service = AIContentService()


### PR DESCRIPTION
## Summary
- Clean up AI content service file and implement logging for retries and failures
- Correct social media image generation route to return placeholder response with proper status code

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d0113c34832f8f8d0a7d56337e3b