### PR TITLE
Fix NameError in learning algorithm hashtag extraction

### DIFF
--- a/src/services/learning_algorithm_service.py
+++ b/src/services/learning_algorithm_service.py
@@ -8,6 +8,7 @@ from collections import defaultdict, Counter
 import statistics
 import math
 import os
+import re
 from dotenv import load_dotenv
 
 # --- NEW: META AUTOMATOR SERVICE CLASS ADDED DIRECTLY HERE ---


### PR DESCRIPTION
## Summary
- import `re` in learning_algorithm_service to enable hashtag parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d262c300832f8970a8d58efb2505