### PR TITLE
Expose SEO and A/B testing tools in dashboard

### DIFF
--- a/frontend/src/AbTesting.jsx
+++ b/frontend/src/AbTesting.jsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import api from './api.js';
+
+function AbTesting() {
+  const [testName, setTestName] = useState('');
+  const [tests, setTests] = useState([]);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const fetchTests = async () => {
+    try {
+      const res = await api.get('/api/ab-testing/tests');
+      setTests(res.data.tests || []);
+    } catch (err) {
+      console.error('Failed to load tests:', err);
+      setError('Failed to load existing tests.');
+    }
+  };
+
+  useEffect(() => {
+    fetchTests();
+  }, []);
+
+  const handleCreateTest = async () => {
+    if (!testName.trim()) {
+      setError('Test name is required.');
+      return;
+    }
+    try {
+      const res = await api.post('/api/ab-testing/create-test', { test_name: testName });
+      setMessage(res.data.message || 'Test created successfully');
+      setTestName('');
+      setError('');
+      fetchTests();
+    } catch (err) {
+      console.error('Failed to create test:', err);
+      setError('Failed to create test.');
+      setMessage('');
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="max-w-lg bg-white p-6 rounded-lg shadow-md space-y-4">
+        <h2 className="text-2xl font-bold">Create A/B Test</h2>
+        <input
+          type="text"
+          value={testName}
+          onChange={(e) => setTestName(e.target.value)}
+          placeholder="Enter test name"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md"
+        />
+        <button
+          type="button"
+          onClick={handleCreateTest}
+          className="px-4 py-2 font-semibold text-white bg-purple-600 rounded-md hover:bg-purple-700"
+        >
+          Create Test
+        </button>
+        {message && <div className="text-green-600">{message}</div>}
+        {error && <div className="text-red-600">{error}</div>}
+      </div>
+
+      <div className="max-w-2xl">
+        <h3 className="text-xl font-semibold mb-4">Existing Tests</h3>
+        {tests.length > 0 ? (
+          <ul className="space-y-2">
+            {tests.map((t) => (
+              <li key={t.id} className="p-4 bg-white rounded-md shadow">
+                <p className="font-medium">{t.name}</p>
+                <p className="text-sm text-gray-500">Status: {t.status}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No tests found.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AbTesting;
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,15 +7,8 @@ import DashboardLayout from './Dashboard.jsx';
 import AccountManager from './AccountManager.jsx';
 import BrandVoiceManager from './BrandVoiceManager.jsx';
 import SocialMediaManager from './SocialMediaManager.jsx';
-
-
-// A simple placeholder for pages that are not yet built
-const ComingSoon = () => (
-  <div className="text-center">
-    <h1 className="text-4xl font-bold">Coming Soon!</h1>
-    <p className="mt-2 text-lg text-gray-600">This feature is under construction.</p>
-  </div>
-);
+import SeoTools from './SeoTools.jsx';
+import AbTesting from './AbTesting.jsx';
 
 // We will create a "mock" user to pass to the layout.
 const mockUser = { id: 1, username: 'Test User' };
@@ -34,8 +27,8 @@ function App() {
           <Route path="accounts" element={<AccountManager user={mockUser} />} />
           <Route path="brand-voices" element={<BrandVoiceManager user={mockUser} />} />
           <Route path="social-media" element={<SocialMediaManager user={mockUser} />} />
-          <Route path="seo-tools" element={<ComingSoon />} />
-          <Route path="ab-testing" element={<ComingSoon />} />
+          <Route path="seo-tools" element={<SeoTools user={mockUser} />} />
+          <Route path="ab-testing" element={<AbTesting user={mockUser} />} />
 
         </Route>
       </Routes>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -6,8 +6,8 @@ const navigation = [
   { name: 'Accounts', href: '/accounts' },
   { name: 'Brand Voices', href: '/brand-voices' },
   { name: 'Social Media Posts', href: '/social-media' },
-  { name: 'SEO Tools', href: '/seo-tools', disabled: true },
-  { name: 'A/B Testing', href: '/ab-testing', disabled: true },
+  { name: 'SEO Tools', href: '/seo-tools' },
+  { name: 'A/B Testing', href: '/ab-testing' },
 ];
 
 // This is a helper component for the navigation links to handle styling

--- a/frontend/src/SeoTools.jsx
+++ b/frontend/src/SeoTools.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import api from './api.js';
+
+function SeoTools() {
+  const [keywordInput, setKeywordInput] = useState('');
+  const [analysis, setAnalysis] = useState(null);
+  const [error, setError] = useState('');
+
+  const handleAnalyze = async () => {
+    const keywords = keywordInput.split(',').map(k => k.trim()).filter(Boolean);
+    if (keywords.length === 0) {
+      setError('Please enter at least one keyword.');
+      setAnalysis(null);
+      return;
+    }
+    setError('');
+    try {
+      const response = await api.post('/api/seo/analyze-keywords', { keywords });
+      setAnalysis(response.data);
+    } catch (err) {
+      console.error('Keyword analysis failed:', err);
+      setError('Failed to analyze keywords.');
+      setAnalysis(null);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto bg-white p-6 rounded-lg shadow-md space-y-4">
+      <h2 className="text-2xl font-bold">SEO Keyword Analyzer</h2>
+      <input
+        type="text"
+        value={keywordInput}
+        onChange={(e) => setKeywordInput(e.target.value)}
+        placeholder="Enter keywords separated by commas"
+        className="w-full px-3 py-2 border border-gray-300 rounded-md"
+      />
+      <button
+        type="button"
+        onClick={handleAnalyze}
+        className="px-4 py-2 font-semibold text-white bg-blue-600 rounded-md hover:bg-blue-700"
+      >
+        Analyze
+      </button>
+      {error && <div className="text-red-600">{error}</div>}
+      {analysis && (
+        <div className="space-y-4">
+          <div>
+            <h3 className="font-semibold">Normalized Keywords</h3>
+            <p>{analysis.input.join(', ')}</p>
+          </div>
+          <div>
+            <h3 className="font-semibold">Suggestions</h3>
+            {analysis.suggestions.length > 0 ? (
+              <ul className="list-disc list-inside">
+                {analysis.suggestions.map((s, idx) => (
+                  <li key={idx}>{s}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>No suggestions available.</p>
+            )}
+          </div>
+          <div>
+            <h3 className="font-semibold">Scores</h3>
+            <ul className="list-disc list-inside">
+              {Object.entries(analysis.scores || {}).map(([kw, score]) => (
+                <li key={kw}>{kw}: {score}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SeoTools;
+

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,8 @@ import logging
 # Import all your blueprints
 from routes.brand_voice_routes import brand_voice_bp
 from routes.social_media import social_media_bp
+from routes.seo_routes import seo_bp
+from routes.ab_testing_routes import ab_testing_bp
 
 
 def create_app():
@@ -21,6 +23,8 @@ def create_app():
 
     app.register_blueprint(brand_voice_bp, url_prefix='/api/brand-voices')
     app.register_blueprint(social_media_bp, url_prefix='/api/social-media')
+    app.register_blueprint(seo_bp, url_prefix='/api/seo')
+    app.register_blueprint(ab_testing_bp, url_prefix='/api/ab-testing')
    
     
     logging.basicConfig(level=logging.INFO)

--- a/src/services/learning_algorithm_service.py
+++ b/src/services/learning_algorithm_service.py
@@ -2,6 +2,7 @@
 
 import json
 import requests
+import re
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 from collections import defaultdict, Counter


### PR DESCRIPTION
## Summary
- Activate navigation links and routes for SEO tools and A/B testing
- Implement SEO keyword analyzer component
- Add A/B testing manager to create and list tests

## Testing
- `pytest -q` *(no tests ran)*
- `npm test` *(npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d1ce41f8832f8e56b59fd6571d05