### PR TITLE
Clean keyword density helper and tests

### DIFF
--- a/src/services/seo_content_service.py
+++ b/src/services/seo_content_service.py
@@ -620,12 +620,10 @@ class SEOContentService:
     def keyword_density(self, text: str, keyword: str) -> Dict:
         """Calculate keyword density for given text and keyword.
 
- codex/create-seo-aware-content-generation-workflow-puwamt
         This helper powers the `/api/seo-tools/keyword-density` endpoint and is
         used by the social media generator to provide real-time SEO feedback.
 
 
- main
         Args:
             text: Content to analyze.
             keyword: Target keyword or phrase.
@@ -635,10 +633,6 @@ class SEOContentService:
             basic suggestion about the density.
         """
 
- codex/create-seo-aware-content-generation-workflow-puwamt
-
- codex/create-seo-aware-content-generation-workflow-begzfl
- main
         if not text or not keyword or not keyword.strip():
             raise ValueError("Text and keyword are required")
 
@@ -650,18 +644,7 @@ class SEOContentService:
         total_words = len(words)
         pattern = r"\b" + re.escape(keyword_lower) + r"\b"
         keyword_count = len(re.findall(pattern, text_lower))
- codex/create-seo-aware-content-generation-workflow-puwamt
 
-
-        if not text or not keyword:
-            raise ValueError("Text and keyword are required")
-
-        words = re.findall(r"\w+", text.lower())
-        total_words = len(words)
-        pattern = r"\b" + re.escape(keyword.lower()) + r"\b"
-        keyword_count = len(re.findall(pattern, text.lower()))
- main
- main
         density = (
             round((keyword_count / total_words) * 100, 2)
             if total_words > 0

--- a/tests/test_seo_keywords.py
+++ b/tests/test_seo_keywords.py
@@ -58,10 +58,7 @@ def test_keyword_density_route():
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["keyword_count"] == 2
- codex/create-seo-aware-content-generation-workflow-puwamt
 
- codex/create-seo-aware-content-generation-workflow-begzfl
- main
 
 
 def test_keyword_density_suggestions():
@@ -81,8 +78,5 @@ def test_keyword_density_phrase():
     text = "Downtown condo for sale. Another downtown condo for sale here."
     result = service.keyword_density(text, "downtown condo for sale")
     assert result["keyword_count"] == 2
- codex/create-seo-aware-content-generation-workflow-puwamt
 
 
- main
- main


### PR DESCRIPTION
## Summary
- remove leftover non-Python scaffolding from `keyword_density`
- clean keyword tests from stray codex markers and restore imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6dda631f8832f92c87ee69ddc5146