### PR TITLE
Avoid duplicate SEO analysis when generating social content

### DIFF
--- a/frontend/src/SocialMediaManager.jsx
+++ b/frontend/src/SocialMediaManager.jsx
@@ -69,13 +69,10 @@ function SocialMediaManager({ user }) {
         topic: topic,
         brand_voice_id: selectedBrandVoice,
       });
-      
+
       setContent(response.data.content || '');
       setHashtags(response.data.hashtags || []);
       setImagePrompt(response.data.image_prompt || '');
-      if (response.data.content) {
-        analyzeKeyword(response.data.content);
-      }
 
     } catch (err) {
       setError('AI content generation failed.');


### PR DESCRIPTION
## Summary
- remove redundant keyword analysis call during content generation
- rely on content & primary keyword effect to run SEO analysis once

## Testing
- `pytest` *(fails: IndentationError in tests/test_seo_keywords.py)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6dda75cd8832f95f3d65a10bea1fa