### PR TITLE
Add debounced keyword analysis to SocialMediaManager

### DIFF
--- a/frontend/src/SocialMediaManager.jsx
+++ b/frontend/src/SocialMediaManager.jsx
@@ -1,5 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import api from './api.js';
+
+// Simple debounce utility
+function debounce(fn, delay) {
+  let timeoutId;
+  return (...args) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delay);
+  };
+}
 
 function SocialMediaManager({ user }) {
   const [posts, setPosts] = useState([]);
@@ -101,11 +110,16 @@ function SocialMediaManager({ user }) {
     }
   };
 
+  const debouncedAnalyze = useRef(debounce(analyzeKeyword, 500));
+
   useEffect(() => {
-    if (content) {
-      analyzeKeyword(content);
+    debouncedAnalyze.current = debounce(analyzeKeyword, 500);
+  }, [primaryKeyword]);
+
+  useEffect(() => {
+    if (content && debouncedAnalyze.current) {
+      debouncedAnalyze.current(content);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content, primaryKeyword]);
 
   const handleCreatePost = async (e) => {


### PR DESCRIPTION
## Summary
- Debounce keyword analysis logic in SocialMediaManager to limit rapid API calls
- Trigger debounced analysis when post content or primary keyword changes

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `pytest` *(fails: IndentationError in tests/test_seo_keywords.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dda928ac832f836b274bb38d2787