### PR TITLE
Handle missing insights when generating social posts

### DIFF
--- a/frontend/src/SocialMediaManager.jsx
+++ b/frontend/src/SocialMediaManager.jsx
@@ -17,6 +17,7 @@ function SocialMediaManager({ user }) {
   const [isLoading, setIsLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState('');
+  const [insightWarning, setInsightWarning] = useState('');
 
   // Form state
   const [selectedAccount, setSelectedAccount] = useState('');
@@ -82,6 +83,11 @@ function SocialMediaManager({ user }) {
       setContent(response.data.content || '');
       setHashtags(response.data.hashtags || []);
       setImagePrompt(response.data.image_prompt || '');
+      if (response.data.insights_used === false) {
+        setInsightWarning('Generated without performance insights due to insufficient data.');
+      } else {
+        setInsightWarning('');
+      }
 
     } catch (err) {
       setError('AI content generation failed.');
@@ -186,6 +192,7 @@ function SocialMediaManager({ user }) {
         </div>
         
         {error && <div className="p-3 bg-red-100 text-red-700 rounded-md">{error}</div>}
+        {insightWarning && <div className="p-3 bg-yellow-100 text-yellow-700 rounded-md">{insightWarning}</div>}
 
         {/* Post Creation Form */}
         <form onSubmit={handleCreatePost} className="space-y-4">

--- a/src/routes/social_media.py
+++ b/src/routes/social_media.py
@@ -69,11 +69,10 @@ def generate_ai_post():
     brand_voice = BrandVoice.query.filter_by(id=brand_voice_id, user_id=user_id).first()
     if not brand_voice: return jsonify({"error": "BrandVoice not found"}), 404
     insights = learning_algorithm_service.get_content_recommendations()
+    insights_used = True
     if not insights or "error" in insights:
-        return (
-            jsonify({"error": "Not enough performance data to generate recommendations."}),
-            503,
-        )
+        insights_used = False
+        insights = {}
     try:
         generated_data = ai_content_service.generate_optimized_post(
             topic=topic,
@@ -82,6 +81,7 @@ def generate_ai_post():
         )
         if "error" in generated_data:
             return jsonify({"error": f"AI generation failed: {generated_data['error']}"}), 500
+        generated_data["insights_used"] = insights_used
         return jsonify(generated_data), 200
     except Exception as e:
         logging.error(f"Error during AI post generation: {str(e)}")

--- a/tests/test_social_media_generation.py
+++ b/tests/test_social_media_generation.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from main import create_app
+from models import db
+from models.brand_voice import BrandVoice
+
+
+def setup_app():
+    app = create_app()
+    app.config.update(TESTING=True)
+    with app.app_context():
+        db.create_all()
+        bv = BrandVoice(id=1, user_id=1, name="Test", description="", post_example="Example")
+        db.session.add(bv)
+        db.session.commit()
+    return app
+
+
+def test_generate_post_fallback_on_insufficient_insights():
+    app = setup_app()
+    client = app.test_client()
+
+    mock_content = {
+        "content": "Generated text",
+        "hashtags": ["#one"],
+        "image_prompt": "img",
+    }
+
+    with patch(
+        "routes.social_media.learning_algorithm_service.get_content_recommendations",
+        return_value={"error": "Insufficient data"},
+    ), patch(
+        "routes.social_media.ai_content_service.generate_optimized_post",
+        return_value=mock_content,
+    ):
+        response = client.post(
+            "/api/social-media/posts/generate",
+            json={"user_id": 1, "topic": "hi", "brand_voice_id": 1},
+        )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["content"] == "Generated text"
+    assert data["insights_used"] is False


### PR DESCRIPTION
## Summary
- Fallback to generic AI post when performance insights are unavailable, returning `insights_used` flag instead of 503
- Display warning in SocialMediaManager UI when posts are generated without performance insights
- Add unit test for post generation fallback behavior

## Testing
- `pytest -q`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2b1722c832fa0a14178a4962e6a