### PR TITLE
Add edit/delete operations for social media posts

### DIFF
--- a/src/models/social_media.py
+++ b/src/models/social_media.py
@@ -39,12 +39,13 @@ class SocialMediaPost(db.Model):
     content = db.Column(db.Text, nullable=False)
     image_prompt = db.Column(db.Text)
     hashtags = db.Column(db.Text) # Stored as a JSON string
+    scheduled_at = db.Column(db.DateTime, nullable=True)
     status = db.Column(db.String(50), default='draft')
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    
-    # Removed unused fields like image_url, scheduled_at, etc. for simplicity
-    
+
+    # Additional fields like image_url can be added in future as needed
+
     def to_dict(self):
         return {
             'id': self.id,
@@ -52,6 +53,7 @@ class SocialMediaPost(db.Model):
             'content': self.content,
             'image_prompt': self.image_prompt,
             'hashtags': json.loads(self.hashtags) if self.hashtags else [],
+            'scheduled_at': self.scheduled_at.isoformat() if self.scheduled_at else None,
             'status': self.status,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None

--- a/src/routes/social_media.py
+++ b/src/routes/social_media.py
@@ -117,6 +117,36 @@ def create_post():
         logging.error(f"Error creating post: {str(e)}")
         return jsonify({"error": "Failed to create post"}), 500
 
+@social_media_bp.route("/posts/<int:post_id>", methods=["PUT"])
+def update_post(post_id):
+    post = SocialMediaPost.query.get_or_404(post_id)
+    data = request.get_json()
+    post.content = data.get("content", post.content)
+    if "hashtags" in data:
+        post.hashtags = json.dumps(data["hashtags"])
+    if "scheduled_at" in data:
+        post.scheduled_at = datetime.fromisoformat(data["scheduled_at"]) if data["scheduled_at"] else None
+    post.updated_at = datetime.utcnow()
+    try:
+        db.session.commit()
+        return jsonify({"success": True, "post": post.to_dict()}), 200
+    except Exception as e:
+        db.session.rollback()
+        logging.error(f"Error updating post: {str(e)}")
+        return jsonify({"error": "Failed to update post"}), 500
+
+@social_media_bp.route("/posts/<int:post_id>", methods=["DELETE"])
+def delete_post(post_id):
+    post = SocialMediaPost.query.get_or_404(post_id)
+    try:
+        db.session.delete(post)
+        db.session.commit()
+        return jsonify({"success": True, "message": "Post deleted"}), 200
+    except Exception as e:
+        db.session.rollback()
+        logging.error(f"Error deleting post: {str(e)}")
+        return jsonify({"error": "Failed to delete post"}), 500
+
 @social_media_bp.route("/posts/<int:post_id>/approve", methods=["POST"])
 def approve_post(post_id):
     post = SocialMediaPost.query.get_or_404(post_id)


### PR DESCRIPTION
## Summary
- support `scheduled_at` on social media posts model
- add PUT and DELETE post routes in social media blueprint
- add edit/delete UI with modal form in SocialMediaManager React component

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7fd027c832fb997845bc57eda3d