### PR TITLE
fix: remove duplicate scheduled_at field in SocialMediaPost serialization

### DIFF
--- a/src/models/social_media.py
+++ b/src/models/social_media.py
@@ -59,7 +59,6 @@ class SocialMediaPost(db.Model):
             'content': self.content,
             'image_prompt': self.image_prompt,
             'hashtags': json.loads(self.hashtags) if self.hashtags else [],
-            'scheduled_at': self.scheduled_at.isoformat() if self.scheduled_at else None,
             'status': self.status,
             'scheduled_at': self.scheduled_at.isoformat() if self.scheduled_at else None,
             'created_at': self.created_at.isoformat() if self.created_at else None,


### PR DESCRIPTION
## Summary
- remove extra `scheduled_at` entry from `SocialMediaPost.to_dict`
- keep remaining serialization fields intact

## Testing
- `pytest -q` *(fails: IndentationError in `src/models/social_media.py` due to unrelated leftover text)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fc2443c4832fb9cd28a818cd7806