### PR TITLE
Fix Alembic env script

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,62 +1,34 @@
 from __future__ import with_statement
- codex/update-test-setup-to-use-migrations
+
 import logging
 from logging.config import fileConfig
 
-from logging.config import fileConfig
-import os
-
- main
 from alembic import context
 from flask import current_app
 
 config = context.config
- codex/update-test-setup-to-use-migrations
-if config.config_file_name:
-
-
-# Interpret the config file for Python logging.
-if config.config_file_name is not None and os.path.exists(config.config_file_name):
- main
+if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = current_app.extensions['migrate'].db.metadata
 
- codex/update-test-setup-to-use-migrations
-def run_migrations_offline():
-    url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={'paramstyle': 'named'})
-    with context.begin_transaction():
-        context.run_migrations()
-
-def run_migrations_online():
-    connectable = current_app.extensions['migrate'].db.engine
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
-        with context.begin_transaction():
-            context.run_migrations()
-
-
 
 def run_migrations_offline() -> None:
     url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
-
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True,
+                      dialect_opts={'paramstyle': 'named'})
     with context.begin_transaction():
         context.run_migrations()
 
 
 def run_migrations_online() -> None:
     connectable = current_app.extensions['migrate'].db.engine
-
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
-
         with context.begin_transaction():
             context.run_migrations()
 
 
- main
 if context.is_offline_mode():
     run_migrations_offline()
 else:


### PR DESCRIPTION
## Summary
- replace corrupted Alembic env.py with standard Flask-Migrate script

## Testing
- `pytest`
- `flask --app src.main:create_app db upgrade`
- `sqlite3 instance/app.db "PRAGMA table_info('social_media_posts');"`
- `curl -s http://127.0.0.1:5001/api/social-media/posts?user_id=1`


------
https://chatgpt.com/codex/tasks/task_e_68c71433dab0832fa6426ea56d310d47