### PR TITLE
Add route test for social media posts

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,62 +1,35 @@
 from __future__ import with_statement
- codex/update-test-setup-to-use-migrations
-import logging
-from logging.config import fileConfig
 
-from logging.config import fileConfig
-import os
-
- main
 from alembic import context
 from flask import current_app
+from logging.config import fileConfig
+import logging
 
 config = context.config
- codex/update-test-setup-to-use-migrations
-if config.config_file_name:
 
-
-# Interpret the config file for Python logging.
-if config.config_file_name is not None and os.path.exists(config.config_file_name):
- main
+if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
 
 target_metadata = current_app.extensions['migrate'].db.metadata
 
- codex/update-test-setup-to-use-migrations
-def run_migrations_offline():
-    url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={'paramstyle': 'named'})
-    with context.begin_transaction():
-        context.run_migrations()
-
-def run_migrations_online():
-    connectable = current_app.extensions['migrate'].db.engine
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
-        with context.begin_transaction():
-            context.run_migrations()
-
-
-
 def run_migrations_offline() -> None:
-    url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
-
+    context.configure(
+        url=current_app.config.get('SQLALCHEMY_DATABASE_URI'),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={'paramstyle': 'named'},
+    )
     with context.begin_transaction():
         context.run_migrations()
-
 
 def run_migrations_online() -> None:
     connectable = current_app.extensions['migrate'].db.engine
-
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
-
         with context.begin_transaction():
             context.run_migrations()
 
-
- main
 if context.is_offline_mode():
     run_migrations_offline()
 else:


### PR DESCRIPTION
## Summary
- add regression test for social media posts listing including scheduled_at
- repair Alembic env file so migrations run in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7143bea08832f9bc4b54ac6335b5d