### PR TITLE
Fix Alembic env for migrations

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,10 +1,4 @@
 from __future__ import with_statement
- codex/add-tests-for-social-media-posts-routes
-
-
-import logging
-from logging.config import fileConfig
- main
 
 from alembic import context
 from flask import current_app
@@ -12,31 +6,20 @@ from logging.config import fileConfig
 import logging
 
 config = context.config
- codex/add-tests-for-social-media-posts-routes
-
-
- main
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 logger = logging.getLogger('alembic.env')
 
 target_metadata = current_app.extensions['migrate'].db.metadata
 
- codex/add-tests-for-social-media-posts-routes
 def run_migrations_offline() -> None:
+    url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
     context.configure(
-        url=current_app.config.get('SQLALCHEMY_DATABASE_URI'),
+        url=url,
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={'paramstyle': 'named'},
     )
-
-
-def run_migrations_offline() -> None:
-    url = current_app.config.get('SQLALCHEMY_DATABASE_URI')
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True,
-                      dialect_opts={'paramstyle': 'named'})
- main
     with context.begin_transaction():
         context.run_migrations()
 
@@ -47,10 +30,6 @@ def run_migrations_online() -> None:
         with context.begin_transaction():
             context.run_migrations()
 
- codex/add-tests-for-social-media-posts-routes
-
-
- main
 if context.is_offline_mode():
     run_migrations_offline()
 else:


### PR DESCRIPTION
## Summary
- restore Alembic env script for proper migrations

## Testing
- `DATABASE_URL=sqlite:////tmp/app.db OPENAI_API_KEY=dummy PYTHONPATH=src flask --app src.main:create_app db upgrade`
- `sqlite3 /tmp/app.db "SELECT * FROM alembic_version;"`


------
https://chatgpt.com/codex/tasks/task_e_68c71a52c45c832fadcb5acac4d6153e