### PR TITLE
Validate user_id query parameters

### DIFF
--- a/src/routes/social_media.py
+++ b/src/routes/social_media.py
@@ -28,8 +28,13 @@ def test_meta_integration():
 @social_media_bp.route("/social-accounts", methods=["GET"])
 def get_accounts():
     user_id = request.args.get("user_id")
-    if not user_id: return jsonify({"error": "user_id is required"}), 400
-    accounts = SocialMediaAccount.query.filter_by(user_id=int(user_id)).all()
+    if not user_id:
+        return jsonify({"error": "user_id is required"}), 400
+    try:
+        user_id = int(user_id)
+    except ValueError:
+        return jsonify({"error": "user_id must be an integer"}), 400
+    accounts = SocialMediaAccount.query.filter_by(user_id=user_id).all()
     return jsonify({"accounts": [account.to_dict() for account in accounts]})
 
 @social_media_bp.route("/social-accounts", methods=["POST"])
@@ -91,9 +96,17 @@ def generate_ai_post():
 @social_media_bp.route("/posts", methods=["GET"])
 def get_posts():
     user_id = request.args.get("user_id")
-    if not user_id: return jsonify({"error": "user_id is required"}), 400
-    query = db.session.query(SocialMediaPost).join(SocialMediaAccount).filter(SocialMediaAccount.user_id == user_id)
-    if request.args.get("status"): query = query.filter(SocialMediaPost.status == request.args.get("status"))
+    if not user_id:
+        return jsonify({"error": "user_id is required"}), 400
+    try:
+        user_id = int(user_id)
+    except ValueError:
+        return jsonify({"error": "user_id must be an integer"}), 400
+    query = db.session.query(SocialMediaPost).join(SocialMediaAccount).filter(
+        SocialMediaAccount.user_id == user_id
+    )
+    if request.args.get("status"):
+        query = query.filter(SocialMediaPost.status == request.args.get("status"))
     posts = query.order_by(SocialMediaPost.created_at.desc()).all()
     return jsonify({"posts": [post.to_dict() for post in posts]})
 

--- a/tests/test_social_media_user_id_validation.py
+++ b/tests/test_social_media_user_id_validation.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+import pytest
+from flask_migrate import Migrate, upgrade
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from main import create_app
+from models import db
+
+
+def setup_app():
+    app = create_app()
+    app.config.update(TESTING=True)
+    Migrate(app, db)
+    with app.app_context():
+        upgrade()
+    return app
+
+
+def test_get_posts_rejects_invalid_user_id():
+    app = setup_app()
+    client = app.test_client()
+    response = client.get("/api/social-media/posts", query_string={"user_id": "abc"})
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "user_id must be an integer"
+
+
+def test_get_accounts_rejects_invalid_user_id():
+    app = setup_app()
+    client = app.test_client()
+    response = client.get("/api/social-media/social-accounts", query_string={"user_id": "xyz"})
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "user_id must be an integer"


### PR DESCRIPTION
## Summary
- ensure social media account and post queries cast `user_id` to `int`
- return `400` errors for non-numeric `user_id` values
- test that post and account list endpoints reject invalid `user_id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c77cb22008832fa94ebd18253b7216