### PR TITLE
Validate user_id in social media account creation

### DIFF
--- a/src/routes/social_media.py
+++ b/src/routes/social_media.py
@@ -42,6 +42,10 @@ def create_account():
     data = request.get_json()
     user_id, name, platform = data.get("user_id"), data.get("account_name"), data.get("platform")
     if not all([user_id, name, platform]): return jsonify({"error": "Missing required fields"}), 400
+    try:
+        user_id = int(user_id)
+    except ValueError:
+        return jsonify({"error": "user_id must be an integer"}), 400
     if SocialMediaAccount.query.filter_by(user_id=user_id, account_name=name).first(): return jsonify({"error": "Account with this name already exists."}), 409
     new_account = SocialMediaAccount(user_id=user_id, account_name=name, platform=platform)
     db.session.add(new_account)

--- a/tests/test_social_media_user_id_validation.py
+++ b/tests/test_social_media_user_id_validation.py
@@ -36,3 +36,14 @@ def test_get_accounts_rejects_invalid_user_id():
     response = client.get("/api/social-media/social-accounts", query_string={"user_id": "xyz"})
     assert response.status_code == 400
     assert response.get_json()["error"] == "user_id must be an integer"
+
+
+def test_create_account_rejects_invalid_user_id():
+    app = setup_app()
+    client = app.test_client()
+    response = client.post(
+        "/api/social-media/social-accounts",
+        json={"user_id": "abc", "account_name": "acct", "platform": "twitter"},
+    )
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "user_id must be an integer"


### PR DESCRIPTION
## Summary
- ensure `create_account` returns 400 when `user_id` is not numeric
- add regression test for invalid `user_id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c783da886c832fbf6518ca67716382