### PR TITLE
Use package import for gunicorn and ensure src on PYTHONPATH

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bash -c 'set -e; : "${DATABASE_URL:?DATABASE_URL environment variable is required}"; flask --app src.main:create_app db upgrade && exec gunicorn src.main:app'
+web: bash -c 'set -e; : "${DATABASE_URL:?DATABASE_URL environment variable is required}"; export PYTHONPATH="${PYTHONPATH}:$(pwd)"; flask --app src.main:create_app db upgrade && exec gunicorn src.main:app'
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ flask --app src.main:create_app db upgrade
 On deployment, the `Procfile` automatically runs database migrations before starting the web server:
 
 ```
-web: flask --app src.main:create_app db upgrade && gunicorn --chdir src main:app
+web: flask --app src.main:create_app db upgrade && gunicorn src.main:app
 ```
+
+Make sure this command runs from the project root so the `src` package is
+available on `PYTHONPATH`. If you need to run it from elsewhere, set
+`PYTHONPATH` to include the project root.
 
 This ensures the database schema is up-to-date on startup.
 


### PR DESCRIPTION
## Summary
- Use `gunicorn src.main:app` in deployment docs
- Export `PYTHONPATH` in `Procfile` so `src` package is discoverable

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c788e66ae8832fb4b91acc24e4fdc5