### PR TITLE
Fix bulk upload parsing and add backend logging

### DIFF
--- a/frontend/src/BrandVoiceManager.jsx
+++ b/frontend/src/BrandVoiceManager.jsx
@@ -74,8 +74,8 @@ function BrandVoiceManager({ user }) {
     e.preventDefault();
     if (!selectedVoiceId) return;
     const examples = bulkExamples
-      .split('\n\n')
-      .map((p) => p.trim())
+      .split(/\r?\n\s*\r?\n/)
+      .map((p) => p.replace(/\r/g, '').trim())
       .filter((p) => p);
     if (examples.length === 0) return;
     try {

--- a/src/routes/brand_voice_routes.py
+++ b/src/routes/brand_voice_routes.py
@@ -84,6 +84,11 @@ def add_examples_batch(voice_id):
             return jsonify({"error": "No valid examples provided."}), 400
         db.session.add_all(new_examples)
         db.session.commit()
+        logging.info(
+            "Saved %d example(s) for brand voice %s.",
+            len(new_examples),
+            voice_id,
+        )
         return jsonify({
             "success": True,
             "examples": [e.to_dict() for e in new_examples]


### PR DESCRIPTION
## Summary
- normalize the bulk upload parsing on the frontend so posts separated by blank lines with carriage returns or whitespace are included
- log successful example batch saves on the backend to make Render logs reflect bulk uploads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98d0725cc832fbf6482213442910b