### PR TITLE
Include brand voice example history in AI prompts

### DIFF
--- a/src/services/ai_content_service.py
+++ b/src/services/ai_content_service.py
@@ -54,10 +54,10 @@ class AIContentService:
                 Windsor-Essex, Ontario, Canada. All content, landmarks, and hashtags must be relevant to this area.
 
             3.  **Tone and Style Guide (Strictly follow this):**
-                Emulate the tone, voice, and structure of this example:
-                --- EXAMPLE START ---
+                Emulate the tone, voice, and structure demonstrated in the following examples. The block between <<<EXAMPLES START>>> and <<<EXAMPLES END>>> contains every sample the client provided (primary and uploaded). Do not copy verbatim—replicate the style, pacing, and personality instead.
+                <<<EXAMPLES START>>>
                 {brand_voice_example}
-                --- EXAMPLE END ---
+                <<<EXAMPLES END>>>
 
             4.  **Performance Optimization Rules (Apply these insights):**
                 - **Content Style:** {performance_insights.get('content_style_suggestions', 'General best practices apply.')}

--- a/tests/test_social_media_generation.py
+++ b/tests/test_social_media_generation.py
@@ -13,7 +13,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.main import create_app
 from src.models import db
+import src.routes.social_media as social_media_routes
 from src.models.brand_voice import BrandVoice
+from src.models.brand_voice_example import BrandVoiceExample
 
 
 def setup_app():
@@ -54,3 +56,114 @@ def test_generate_post_fallback_on_insufficient_insights():
     data = response.get_json()
     assert data["content"] == "Generated text"
     assert data["insights_used"] is False
+
+
+def test_generate_post_combines_all_examples():
+    app = setup_app()
+    client = app.test_client()
+
+    with app.app_context():
+        db.session.add_all(
+            [
+                BrandVoiceExample(
+                    brand_voice_id=1,
+                    content="Secondary sample one",
+                ),
+                BrandVoiceExample(
+                    brand_voice_id=1,
+                    content="Secondary sample two",
+                ),
+            ]
+        )
+        db.session.commit()
+
+    mock_response = {
+        "content": "Generated",
+        "hashtags": ["#one"],
+        "image_prompt": "img",
+    }
+
+    with patch(
+        "src.routes.social_media.learning_algorithm_service.get_content_recommendations",
+        return_value={},
+    ), patch(
+        "src.routes.social_media.ai_content_service.generate_optimized_post",
+        return_value=mock_response,
+    ) as mock_generate:
+        response = client.post(
+            "/api/social-media/posts/generate",
+            json={"user_id": 1, "topic": "hi", "brand_voice_id": 1},
+        )
+
+    assert response.status_code == 200
+    called_kwargs = mock_generate.call_args.kwargs
+    assert called_kwargs["brand_voice_example"] == (
+        "Example\n\nSecondary sample one\n\nSecondary sample two"
+    )
+
+
+def test_generate_post_uses_primary_when_no_extras():
+    app = setup_app()
+    client = app.test_client()
+
+    mock_response = {
+        "content": "Generated",
+        "hashtags": ["#one"],
+        "image_prompt": "img",
+    }
+
+    with patch(
+        "src.routes.social_media.learning_algorithm_service.get_content_recommendations",
+        return_value={},
+    ), patch(
+        "src.routes.social_media.ai_content_service.generate_optimized_post",
+        return_value=mock_response,
+    ) as mock_generate:
+        response = client.post(
+            "/api/social-media/posts/generate",
+            json={"user_id": 1, "topic": "hi", "brand_voice_id": 1},
+        )
+
+    assert response.status_code == 200
+    called_kwargs = mock_generate.call_args.kwargs
+    assert called_kwargs["brand_voice_example"] == "Example"
+
+
+def test_generate_post_truncates_long_example_block(monkeypatch):
+    app = setup_app()
+    client = app.test_client()
+
+    with app.app_context():
+        db.session.add(
+            BrandVoiceExample(
+                brand_voice_id=1,
+                content="A" * 120,
+            )
+        )
+        db.session.commit()
+
+    monkeypatch.setattr(social_media_routes, "BRAND_VOICE_EXAMPLES_MAX_CHARS", 50)
+
+    mock_response = {
+        "content": "Generated",
+        "hashtags": ["#one"],
+        "image_prompt": "img",
+    }
+
+    with patch(
+        "src.routes.social_media.learning_algorithm_service.get_content_recommendations",
+        return_value={},
+    ), patch(
+        "src.routes.social_media.ai_content_service.generate_optimized_post",
+        return_value=mock_response,
+    ) as mock_generate:
+        response = client.post(
+            "/api/social-media/posts/generate",
+            json={"user_id": 1, "topic": "hi", "brand_voice_id": 1},
+        )
+
+    assert response.status_code == 200
+    combined_examples = mock_generate.call_args.kwargs["brand_voice_example"]
+    assert combined_examples.startswith("Example\n\n")
+    assert len(combined_examples) <= 50
+    assert combined_examples.endswith("A" * (50 - len("Example\n\n")))


### PR DESCRIPTION
## Summary
- combine primary brand voice samples with saved examples when generating AI posts, trimming blanks and capping total length
- adjust the OpenAI prompt to label the merged example block with explicit delimiters so every upload is sent to the model
- extend social media generation tests to validate combined examples, fallback behaviour, and truncation safeguards

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca1d3b8434832facf214229cf6cff0