### PR TITLE
feat: share SEO keyword sets with social media manager

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,29 +8,32 @@ import AccountManager from './AccountManager.jsx';
 import BrandVoiceManager from './BrandVoiceManager.jsx';
 import SocialMediaManager from './SocialMediaManager.jsx';
 import SeoTools from './SeoTools.jsx';
+import { KeywordSetsProvider } from './KeywordSetsContext.jsx';
 
 // We will create a "mock" user to pass to the layout.
 const mockUser = { id: 1, username: 'Test User' };
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        {/* The DashboardLayout component now acts as the main layout for all pages */}
-        <Route path="/" element={<DashboardLayout user={mockUser} onLogout={() => {}} />}>
-          
-          {/* Redirect from the base path "/" to the default "/accounts" page */}
-          <Route index element={<Navigate to="/accounts" replace />} />
-          
-          {/* All pages are now nested inside the layout and have their own paths */}
-          <Route path="accounts" element={<AccountManager user={mockUser} />} />
-          <Route path="brand-voices" element={<BrandVoiceManager user={mockUser} />} />
-          <Route path="social-media" element={<SocialMediaManager user={mockUser} />} />
-          <Route path="seo-tools" element={<SeoTools user={mockUser} />} />
+    <KeywordSetsProvider>
+      <Router>
+        <Routes>
+          {/* The DashboardLayout component now acts as the main layout for all pages */}
+          <Route path="/" element={<DashboardLayout user={mockUser} onLogout={() => {}} />}>
 
-        </Route>
-      </Routes>
-    </Router>
+            {/* Redirect from the base path "/" to the default "/accounts" page */}
+            <Route index element={<Navigate to="/accounts" replace />} />
+
+            {/* All pages are now nested inside the layout and have their own paths */}
+            <Route path="accounts" element={<AccountManager user={mockUser} />} />
+            <Route path="brand-voices" element={<BrandVoiceManager user={mockUser} />} />
+            <Route path="social-media" element={<SocialMediaManager user={mockUser} />} />
+            <Route path="seo-tools" element={<SeoTools user={mockUser} />} />
+
+          </Route>
+        </Routes>
+      </Router>
+    </KeywordSetsProvider>
   );
 }
 

--- a/frontend/src/KeywordSetsContext.jsx
+++ b/frontend/src/KeywordSetsContext.jsx
@@ -1,0 +1,113 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const KeywordSetsContext = createContext(null);
+const STORAGE_KEY = 'seo-keyword-sets';
+
+function normalizeHashtag(value) {
+  if (!value) return '';
+  const cleaned = value
+    .toString()
+    .trim()
+    .replace(/[#\s]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .join('');
+
+  if (!cleaned) {
+    return '';
+  }
+
+  return `#${cleaned}`;
+}
+
+export function KeywordSetsProvider({ children }) {
+  const [savedKeywordSets, setSavedKeywordSets] = useState(() => {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return [];
+      }
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.map((set) => ({
+        ...set,
+        hashtags: Array.isArray(set?.hashtags)
+          ? set.hashtags.filter(Boolean)
+          : [],
+        keywords: Array.isArray(set?.keywords)
+          ? set.keywords.filter(Boolean)
+          : [],
+      }));
+    } catch (err) {
+      console.error('Failed to read stored keyword sets', err);
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(savedKeywordSets));
+    } catch (err) {
+      console.error('Failed to persist keyword sets', err);
+    }
+  }, [savedKeywordSets]);
+
+  const addKeywordSet = (payload) => {
+    setSavedKeywordSets((prev) => {
+      const keywords = Array.isArray(payload.keywords)
+        ? payload.keywords.filter(Boolean)
+        : [];
+      const hashtags = Array.isArray(payload.hashtags)
+        ? payload.hashtags.map(normalizeHashtag).filter(Boolean)
+        : [];
+      const primaryKeyword = payload.primaryKeyword || keywords[0] || '';
+      const next = {
+        id: payload.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        name: payload.name || primaryKeyword || 'Saved Keywords',
+        keywords,
+        primaryKeyword,
+        hashtags,
+      };
+
+      const filtered = prev.filter((set) => set.id !== next.id && set.name !== next.name);
+      return [...filtered, next];
+    });
+  };
+
+  const removeKeywordSet = (id) => {
+    setSavedKeywordSets((prev) => prev.filter((set) => set.id !== id));
+  };
+
+  const value = useMemo(
+    () => ({
+      savedKeywordSets,
+      addKeywordSet,
+      removeKeywordSet,
+    }),
+    [savedKeywordSets],
+  );
+
+  return (
+    <KeywordSetsContext.Provider value={value}>
+      {children}
+    </KeywordSetsContext.Provider>
+  );
+}
+
+export function useKeywordSets() {
+  const context = useContext(KeywordSetsContext);
+  if (!context) {
+    throw new Error('useKeywordSets must be used within a KeywordSetsProvider');
+  }
+  return context;
+}
+
+export default KeywordSetsContext;

--- a/frontend/src/SeoTools.jsx
+++ b/frontend/src/SeoTools.jsx
@@ -1,10 +1,15 @@
 import React, { useState } from 'react';
 import api from './api.js';
+import { useKeywordSets } from './KeywordSetsContext.jsx';
 
 function SeoTools() {
   const [keywordInput, setKeywordInput] = useState('');
+  const [keywordSetName, setKeywordSetName] = useState('');
+  const [hashtagInput, setHashtagInput] = useState('');
   const [analysis, setAnalysis] = useState(null);
   const [error, setError] = useState('');
+  const [saveMessage, setSaveMessage] = useState('');
+  const { savedKeywordSets, addKeywordSet, removeKeywordSet } = useKeywordSets();
 
   const handleAnalyze = async () => {
     const keywords = keywordInput.split(',').map(k => k.trim()).filter(Boolean);
@@ -24,24 +29,115 @@ function SeoTools() {
     }
   };
 
+  const handleSaveKeywordSet = () => {
+    const keywords = keywordInput.split(',').map(k => k.trim()).filter(Boolean);
+    if (keywords.length === 0) {
+      setError('Please enter keywords before saving.');
+      return;
+    }
+
+    const hashtags = hashtagInput
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+
+    addKeywordSet({
+      name: keywordSetName.trim() || keywords[0],
+      keywords,
+      primaryKeyword: keywords[0],
+      hashtags: hashtags.length > 0 ? hashtags : keywords.slice(1),
+    });
+
+    setError('');
+    setKeywordSetName('');
+    setHashtagInput('');
+    setSaveMessage('Keyword set saved for Social Media Manager.');
+    setTimeout(() => setSaveMessage(''), 2500);
+  };
+
+  const handleRemoveSet = (id) => {
+    removeKeywordSet(id);
+  };
+
   return (
-    <div className="max-w-xl mx-auto bg-white p-6 rounded-lg shadow-md space-y-4">
+    <div className="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow-md space-y-6">
       <h2 className="text-2xl font-bold">SEO Keyword Analyzer</h2>
-      <input
-        type="text"
-        value={keywordInput}
-        onChange={(e) => setKeywordInput(e.target.value)}
-        placeholder="Enter keywords separated by commas"
-        className="w-full px-3 py-2 border border-gray-300 rounded-md"
-      />
-      <button
-        type="button"
-        onClick={handleAnalyze}
-        className="px-4 py-2 font-semibold text-white bg-blue-600 rounded-md hover:bg-blue-700"
-      >
-        Analyze
-      </button>
-      {error && <div className="text-red-600">{error}</div>}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="space-y-4">
+          <input
+            type="text"
+            value={keywordInput}
+            onChange={(e) => setKeywordInput(e.target.value)}
+            placeholder="Enter keywords separated by commas"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md"
+          />
+          <input
+            type="text"
+            value={hashtagInput}
+            onChange={(e) => setHashtagInput(e.target.value)}
+            placeholder="Optional hashtags (comma separated)"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md"
+          />
+          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-3 space-y-3 sm:space-y-0">
+            <input
+              type="text"
+              value={keywordSetName}
+              onChange={(e) => setKeywordSetName(e.target.value)}
+              placeholder="Name this keyword set"
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-md"
+            />
+            <button
+              type="button"
+              onClick={handleSaveKeywordSet}
+              className="px-4 py-2 font-semibold text-white bg-green-600 rounded-md hover:bg-green-700"
+            >
+              Save for Social Media
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={handleAnalyze}
+            className="px-4 py-2 font-semibold text-white bg-blue-600 rounded-md hover:bg-blue-700"
+          >
+            Analyze
+          </button>
+          {saveMessage && <div className="text-green-600 text-sm">{saveMessage}</div>}
+          {error && <div className="text-red-600">{error}</div>}
+        </div>
+
+        <div className="bg-gray-50 border rounded-lg p-4 space-y-3">
+          <h3 className="text-lg font-semibold">Saved Keyword Sets</h3>
+          {savedKeywordSets.length === 0 ? (
+            <p className="text-sm text-gray-600">No keyword sets saved yet.</p>
+          ) : (
+            <ul className="space-y-3 max-h-64 overflow-y-auto">
+              {savedKeywordSets.map((set) => (
+                <li key={set.id} className="p-3 bg-white border rounded-md">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="font-semibold">{set.name}</p>
+                      <p className="text-sm text-gray-600">Primary: {set.primaryKeyword}</p>
+                      {set.hashtags?.length > 0 && (
+                        <p className="text-xs text-gray-500">Hashtags: {set.hashtags.join(', ')}</p>
+                      )}
+                      {set.keywords?.length > 0 && (
+                        <p className="text-xs text-gray-500">Keywords: {set.keywords.join(', ')}</p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveSet(set.id)}
+                      className="text-sm text-red-600 hover:text-red-800"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
       {analysis && (
         <div className="space-y-4">
           <div>


### PR DESCRIPTION
## Summary
- add a shared keyword set context backed by localStorage so SEO tools can expose saved sets
- allow SEO Tools to save named keyword/hashtag collections and review or remove them
- let Social Media Manager import saved keyword sets to populate the primary keyword and hashtags

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca2822c330832fadce45ed331ad33e