### PR TITLE
Handle undefined initial saved bundles in SeoTools

### DIFF
--- a/frontend/src/SeoTools.jsx
+++ b/frontend/src/SeoTools.jsx
@@ -3,7 +3,7 @@ import api from './api.js';
 import { useKeywordSets } from './KeywordSetsContext.jsx';
 
 function SeoTools({
-  initialSavedBundles = [],
+  initialSavedBundles,
   onBundlesChange = () => {},
   onBundleSelected = () => {},
 }) {
@@ -14,11 +14,14 @@ function SeoTools({
   const [error, setError] = useState('');
  codex/add-keyword-management-ui-features
   const [selectedKeywords, setSelectedKeywords] = useState([]);
-  const [savedBundles, setSavedBundles] = useState(() => initialSavedBundles);
+  const [savedBundles, setSavedBundles] = useState(() => initialSavedBundles ?? []);
   const [bundleName, setBundleName] = useState('');
   const [statusMessage, setStatusMessage] = useState('');
 
   useEffect(() => {
+    if (initialSavedBundles === undefined) {
+      return;
+    }
     setSavedBundles(initialSavedBundles);
   }, [initialSavedBundles]);
 


### PR DESCRIPTION
## Summary
- allow SeoTools to accept undefined `initialSavedBundles` without creating a new array in the signature
- initialize the saved bundles state from the prop when provided while defaulting to an empty list otherwise
- prevent the syncing effect from overwriting local bundles when the prop is `undefined`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca2e44a998832fa62e93d959165238