### PR TITLE
Add Lucide icons to dashboard navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.0",
         "date-fns": "^3.6.0",
+        "lucide-react": "^0.544.0",
         "react": "^18.2.0",
         "react-datepicker": "^7.3.0",
         "react-dom": "^18.2.0",
@@ -2216,6 +2217,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "date-fns": "^3.6.0",
+    "lucide-react": "^0.544.0",
     "react": "^18.2.0",
     "react-datepicker": "^7.3.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,25 +1,34 @@
 import React from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
+import {
+  LayoutDashboard,
+  Megaphone,
+  Search,
+  Share2,
+  Users,
+} from 'lucide-react';
 
 // You can define your navigation links here
 const navigation = [
-  { name: 'Accounts', href: '/accounts' },
-  { name: 'Brand Voices', href: '/brand-voices' },
-  { name: 'Social Media Posts', href: '/social-media' },
-  { name: 'SEO Tools', href: '/seo-tools' },
+  { name: 'Accounts', href: '/accounts', icon: Users },
+  { name: 'Brand Voices', href: '/brand-voices', icon: Megaphone },
+  { name: 'Social Media Posts', href: '/social-media', icon: Share2 },
+  { name: 'SEO Tools', href: '/seo-tools', icon: Search },
 ];
 
 // This is a helper component for the navigation links to handle styling
 function NavItem({ item }) {
-  const baseClasses = "group flex items-center px-3 py-2 text-sm font-medium rounded-md";
+  const baseClasses = "group flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md";
   const activeClasses = "bg-gray-900 text-white";
   const inactiveClasses = "text-gray-300 hover:bg-gray-700 hover:text-white";
   const disabledClasses = "text-gray-500 cursor-not-allowed";
+  const Icon = item.icon;
 
   if (item.disabled) {
     return (
       <span className={`${baseClasses} ${disabledClasses}`} title="Coming Soon">
-        {item.name}
+        {Icon ? <Icon className="h-4 w-4" aria-hidden="true" /> : null}
+        <span>{item.name}</span>
       </span>
     );
   }
@@ -29,7 +38,8 @@ function NavItem({ item }) {
       to={item.href}
       className={({ isActive }) => `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`}
     >
-      {item.name}
+      {Icon ? <Icon className="h-4 w-4" aria-hidden="true" /> : null}
+      <span>{item.name}</span>
     </NavLink>
   );
 }
@@ -42,6 +52,7 @@ function DashboardLayout({ user, onLogout }) {
         <div className="flex w-64 flex-col bg-gray-800">
           <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
             <div className="flex flex-shrink-0 items-center px-4">
+              <LayoutDashboard className="mr-3 h-6 w-6 text-white" aria-hidden="true" />
               <h1 className="text-2xl font-bold text-white">Real Estate AI</h1>
             </div>
             <nav className="mt-5 flex-1 space-y-1 px-2">


### PR DESCRIPTION
## Summary
- install the lucide-react package for direct React icon imports
- render Lucide icons in the dashboard sidebar and app header instead of plain text labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cacc124878832fa080606b92f50663