### PR TITLE
Configure Tailwind font family using default theme fallback

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -5,7 +7,11 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- import Tailwind's default theme within the Tailwind config
- extend the sans font family to prepend Inter while preserving the default fonts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cacc0f96c4832fa15d7822a87ac6c6