### PR TITLE
Revamp dashboard navigation layout

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -18,16 +18,16 @@ const navigation = [
 
 // This is a helper component for the navigation links to handle styling
 function NavItem({ item }) {
-  const baseClasses = "group flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md";
-  const activeClasses = "bg-gray-900 text-white";
-  const inactiveClasses = "text-gray-300 hover:bg-gray-700 hover:text-white";
+  const baseClasses = "group flex items-center gap-3 px-3 py-3 text-sm font-medium rounded-lg";
+  const activeClasses = "bg-gray-800 text-primary-400";
+  const inactiveClasses = "text-gray-300 hover:bg-gray-800 hover:text-white";
   const disabledClasses = "text-gray-500 cursor-not-allowed";
   const Icon = item.icon;
 
   if (item.disabled) {
     return (
       <span className={`${baseClasses} ${disabledClasses}`} title="Coming Soon">
-        {Icon ? <Icon className="h-4 w-4" aria-hidden="true" /> : null}
+        {Icon ? <Icon className="h-5 w-5" aria-hidden="true" /> : null}
         <span>{item.name}</span>
       </span>
     );
@@ -38,7 +38,7 @@ function NavItem({ item }) {
       to={item.href}
       className={({ isActive }) => `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`}
     >
-      {Icon ? <Icon className="h-4 w-4" aria-hidden="true" /> : null}
+      {Icon ? <Icon className="h-5 w-5" aria-hidden="true" /> : null}
       <span>{item.name}</span>
     </NavLink>
   );
@@ -48,32 +48,32 @@ function DashboardLayout({ user, onLogout }) {
   return (
     <div className="flex h-screen bg-gray-100">
       {/* Static sidebar for desktop */}
-      <div className="flex flex-shrink-0">
-        <div className="flex w-64 flex-col bg-gray-800">
-          <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
-            <div className="flex flex-shrink-0 items-center px-4">
-              <LayoutDashboard className="mr-3 h-6 w-6 text-white" aria-hidden="true" />
-              <h1 className="text-2xl font-bold text-white">Real Estate AI</h1>
-            </div>
-            <nav className="mt-5 flex-1 space-y-1 px-2">
-              {navigation.map((item) => (
-                <NavItem key={item.name} item={item} />
-              ))}
-            </nav>
+      <aside className="bg-gray-900 text-white w-64 min-h-screen p-4 flex flex-col gap-6">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center justify-center w-8 h-8 bg-primary-600 rounded-lg">
+            <LayoutDashboard className="h-5 w-5" aria-hidden="true" />
           </div>
-          <div className="flex flex-shrink-0 border-t border-gray-700 p-4">
-            <div className="flex w-full items-center justify-between">
-                <span className="text-sm font-medium text-white">{user.username}</span>
-                <button
-                  onClick={onLogout}
-                  className="ml-3 inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white shadow-sm hover:bg-red-700"
-                >
-                  Logout
-                </button>
-            </div>
+          <h1 className="text-xl font-semibold">Real Estate AI</h1>
+        </div>
+
+        <nav className="flex-1 flex flex-col gap-1">
+          {navigation.map((item) => (
+            <NavItem key={item.name} item={item} />
+          ))}
+        </nav>
+
+        <div className="border-t border-gray-800 pt-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-white">{user.username}</span>
+            <button
+              onClick={onLogout}
+              className="inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white shadow-sm hover:bg-red-700"
+            >
+              Logout
+            </button>
           </div>
         </div>
-      </div>
+      </aside>
 
       {/* Main content area */}
       <main className="flex-1 overflow-y-auto bg-gray-200 p-8">


### PR DESCRIPTION
## Summary
- wrap the dashboard sidebar navigation with the updated layout container
- add a branded header block with the new icon treatment
- refresh nav item styling to use the updated spacing, hover, and active states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad4f6c9dc832fb5ef1e8b9f76f3d4