### PR TITLE
Add font-sans class to dashboard layout root container

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -46,7 +46,7 @@ function NavItem({ item }) {
 
 function DashboardLayout({ user, onLogout }) {
   return (
-    <div className="flex h-screen bg-gray-100">
+    <div className="flex h-screen bg-gray-100 font-sans">
       {/* Static sidebar for desktop */}
       <aside className="bg-gray-900 text-white w-64 min-h-screen p-4 flex flex-col gap-6">
         <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add the `font-sans` class to the dashboard layout's root container to enforce the base sans-serif font

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cada88cccc832f976d88e9afa8a1d1