### PR TITLE
Handle missing property area safely

### DIFF
--- a/frontend/src/pages/PropertiesPage.jsx
+++ b/frontend/src/pages/PropertiesPage.jsx
@@ -148,7 +148,7 @@ const PropertyCard = ({ property, onGenerateContent, generationState, generatedC
     text: 'text-gray-600',
   };
 
-  const areaText = typeof property.area === 'number' ? property.area.toLocaleString() : '—';
+  const areaText = typeof property?.area === 'number' ? property.area.toLocaleString() : '—';
 
   return (
     <article className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg">


### PR DESCRIPTION
## Summary
- guard the property area display by ensuring the component checks for a numeric value before formatting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb715144b8832fae05447a5adb3f5f