### PR TITLE
Serve SPA assets from Flask static root

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,7 @@ def _ensure_database_schema(app: Flask) -> None:
 
 
 def create_app():
-    app = Flask(__name__)
+    app = Flask(__name__, static_folder='static', static_url_path='')
     app.config.from_object(Config)
     db.init_app(app)
     Migrate(app, db)
@@ -56,7 +56,7 @@ def create_app():
 
     @app.route('/')
     def index():
-        return "Backend is running!"
+        return app.send_static_file('index.html')
 
     return app
 


### PR DESCRIPTION
## Summary
- configure the Flask application to expose the bundled static assets at the root path
- serve the built single-page app index.html from the root route

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'apify_client')*


------
https://chatgpt.com/codex/tasks/task_e_68cb74ae5a94832f9c21ba48db1f5ab9