### PR TITLE
Add catch-all route for SPA requests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,6 @@
-from flask import Flask
+import os
+
+from flask import Flask, abort, send_from_directory
 from flask_cors import CORS
 from flask_migrate import Migrate, upgrade
 import logging
@@ -54,8 +56,18 @@ def create_app():
 
     _ensure_database_schema(app)
 
-    @app.route('/')
-    def index():
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def index(path):
+        if path.startswith('api/'):
+            abort(404)
+
+        static_dir = app.static_folder
+        if path and static_dir:
+            full_path = os.path.join(static_dir, path)
+            if os.path.isfile(full_path):
+                return send_from_directory(static_dir, path)
+
         return app.send_static_file('index.html')
 
     return app


### PR DESCRIPTION
## Summary
- add a catch-all Flask route that returns the React index.html for unknown paths
- ignore API-prefixed paths and let real static files pass through to keep existing functionality

## Testing
- pytest *(fails: missing `apify_client` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0d4e3fc8832fa4a4f91a63db7b0f