### PR TITLE
Handle bare /api path in catch-all

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -59,7 +59,7 @@ def create_app():
     @app.route('/', defaults={'path': ''})
     @app.route('/<path:path>')
     def index(path):
-        if path.startswith('api/'):
+        if path == 'api' or path.startswith('api/'):
             abort(404)
 
         static_dir = app.static_folder


### PR DESCRIPTION
## Summary
- ensure the catch-all index route aborts for the bare `/api` path in addition to prefixed API routes

## Testing
- pytest
- python - <<'PY' # verify /api returns 404 while other API and static routes succeed
from src.main import create_app
from src.models import db
import os

app = create_app()
app.testing = True
app.static_folder = os.path.join(os.getcwd(), 'static')
with app.app_context():
    db.create_all()

client = app.test_client()

for path in ['/', '/api', '/api/users', '/js/social-media-automation.js']:
    resp = client.get(path)
    print(path, resp.status_code)
    if path == '/api/users':
        print('body', resp.get_json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cc1aae25e4832f9784d93eda94ead3