### PR TITLE
Adopt new dashboard layout styling

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import {
   Building2,
   LayoutDashboard,
   Megaphone,
+  Menu,
   Search,
   Share2,
   Users,
+  X,
 } from 'lucide-react';
 
-// You can define your navigation links here
 const navigation = [
   { name: 'Accounts', href: '/accounts', icon: Users },
   { name: 'Properties', href: '/properties', icon: Building2 },
@@ -18,18 +19,13 @@ const navigation = [
   { name: 'SEO Tools', href: '/seo-tools', icon: Search },
 ];
 
-// This is a helper component for the navigation links to handle styling
-function NavItem({ item }) {
-  const baseClasses = "group flex items-center gap-3 px-3 py-3 text-sm font-medium rounded-lg";
-  const activeClasses = "bg-gray-800 text-primary-400";
-  const inactiveClasses = "text-gray-300 hover:bg-gray-800 hover:text-white";
-  const disabledClasses = "text-gray-500 cursor-not-allowed";
+function NavItem({ item, onNavigate }) {
   const Icon = item.icon;
 
   if (item.disabled) {
     return (
-      <span className={`${baseClasses} ${disabledClasses}`} title="Coming Soon">
-        {Icon ? <Icon className="h-5 w-5" aria-hidden="true" /> : null}
+      <span className="nav-item disabled" title="Coming Soon">
+        {Icon ? <Icon className="nav-icon" aria-hidden="true" /> : null}
         <span>{item.name}</span>
       </span>
     );
@@ -38,50 +34,95 @@ function NavItem({ item }) {
   return (
     <NavLink
       to={item.href}
-      className={({ isActive }) => `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`}
+      className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}
+      onClick={onNavigate}
     >
-      {Icon ? <Icon className="h-5 w-5" aria-hidden="true" /> : null}
+      {Icon ? <Icon className="nav-icon" aria-hidden="true" /> : null}
       <span>{item.name}</span>
     </NavLink>
   );
 }
 
 function DashboardLayout({ user, onLogout }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const username = user?.username ?? 'User';
+  const userInitial = username.charAt(0).toUpperCase();
+
+  const handleToggleMenu = () => {
+    setMenuOpen((open) => !open);
+  };
+
+  const handleCloseMenu = () => {
+    setMenuOpen(false);
+  };
+
   return (
-    <div className="flex h-screen bg-gray-100 font-sans">
-      {/* Static sidebar for desktop */}
-      <aside className="bg-gray-900 text-white w-64 min-h-screen p-4 flex flex-col gap-6">
-        <div className="flex items-center gap-3">
-          <div className="flex items-center justify-center w-8 h-8 bg-primary-600 rounded-lg">
-            <LayoutDashboard className="h-5 w-5" aria-hidden="true" />
+    <div className="dashboard-layout">
+      <aside className={`sidebar${menuOpen ? ' open' : ''}`}>
+        <div className="sidebar-header">
+          <div className="brand">
+            <span className="brand-icon">
+              <LayoutDashboard aria-hidden="true" />
+            </span>
+            <div className="brand-name">
+              <span>Control</span>
+              <span>Real Estate AI</span>
+            </div>
           </div>
-          <h1 className="text-xl font-semibold">Real Estate AI</h1>
         </div>
-
-        <nav className="flex-1 flex flex-col gap-1">
-          {navigation.map((item) => (
-            <NavItem key={item.name} item={item} />
-          ))}
+        <nav className="nav-section" aria-label="Primary">
+          <span className="nav-label">Navigation</span>
+          <ul className="nav-list">
+            {navigation.map((item) => (
+              <li key={item.name}>
+                <NavItem item={item} onNavigate={handleCloseMenu} />
+              </li>
+            ))}
+          </ul>
         </nav>
-
-        <div className="border-t border-gray-800 pt-4">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-white">{user.username}</span>
-            <button
-              onClick={onLogout}
-              className="inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white shadow-sm hover:bg-red-700"
-            >
-              Logout
-            </button>
+        <div className="sidebar-footer">
+          <div className="user-card">
+            <span className="avatar" aria-hidden="true">
+              {userInitial}
+            </span>
+            <div className="user-meta">
+              <span className="user-name">{username}</span>
+              <span className="user-role">Administrator</span>
+            </div>
           </div>
+          <button type="button" className="logout-button" onClick={onLogout}>
+            Logout
+          </button>
         </div>
       </aside>
-
-      {/* Main content area */}
-      <main className="flex-1 overflow-y-auto bg-gray-200 p-8">
-        {/* The Outlet is where the different pages will be rendered */}
-        <Outlet />
-      </main>
+      {menuOpen ? <div className="sidebar-backdrop" onClick={handleCloseMenu} /> : null}
+      <div className="main-content">
+        <header className="header">
+          <button
+            type="button"
+            className={`menu-toggle${menuOpen ? ' open' : ''}`}
+            onClick={handleToggleMenu}
+            aria-label={`${menuOpen ? 'Close' : 'Open'} navigation menu`}
+          >
+            {menuOpen ? <X aria-hidden="true" /> : <Menu aria-hidden="true" />}
+          </button>
+          <div className="header-info">
+            <h1>Welcome back, {username}</h1>
+            <p>Manage your accounts, listings, and marketing automations from one hub.</p>
+          </div>
+          <div className="header-actions">
+            <div className="profile-chip">
+              <span className="avatar" aria-hidden="true">
+                {userInitial}
+              </span>
+              <span>{username}</span>
+            </div>
+          </div>
+        </header>
+        <section className="content-area">
+          <Outlet />
+        </section>
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,5 @@
+@import './style.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,0 +1,415 @@
+:root {
+  --font-family-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-background: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f0f2f9;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-sidebar: #0f172a;
+  --color-sidebar-accent: rgba(255, 255, 255, 0.08);
+  --color-sidebar-active: #ffffff;
+  --shadow-soft: 0 10px 40px rgba(15, 23, 42, 0.12);
+  --shadow-header: 0 12px 30px rgba(15, 23, 42, 0.06);
+  --sidebar-width: 280px;
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  line-height: 1.6;
+  min-height: 100%;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+}
+
+.dashboard-layout {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+  background: var(--color-background);
+  position: relative;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--color-sidebar);
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  padding: 32px 24px;
+  gap: 32px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  z-index: 30;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-weight: 600;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+}
+
+.brand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--color-primary), #4f46e5);
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.35);
+}
+
+.brand-icon svg {
+  width: 22px;
+  height: 22px;
+  color: #ffffff;
+}
+
+.brand-name {
+  display: flex;
+  flex-direction: column;
+}
+
+.brand-name span:first-child {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.3em;
+}
+
+.brand-name span:last-child {
+  font-size: 1.2rem;
+  color: #ffffff;
+}
+
+.nav-section {
+  display: grid;
+  gap: 12px;
+  flex: 1;
+}
+
+.nav-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  color: rgba(255, 255, 255, 0.75);
+  text-decoration: none;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.nav-item:hover {
+  background: var(--color-sidebar-accent);
+  color: #ffffff;
+}
+
+.nav-item:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.nav-item.active {
+  background: #ffffff;
+  color: var(--color-sidebar);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
+}
+
+.nav-item.active .nav-icon {
+  color: var(--color-primary);
+}
+
+.nav-item.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background: transparent;
+}
+
+.nav-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.user-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.user-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-role {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.logout-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.logout-button:hover {
+  background: rgba(255, 255, 255, 0.24);
+  transform: translateY(-1px);
+}
+
+.logout-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
+.main-content {
+  flex: 1;
+  margin-left: var(--sidebar-width);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-muted) 100%);
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 32px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-header);
+  z-index: 20;
+}
+
+.menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.menu-toggle svg {
+  width: 22px;
+  height: 22px;
+}
+
+.menu-toggle:hover {
+  background: var(--color-surface-muted);
+  transform: translateY(-1px);
+}
+
+.header-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.header-info h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+
+.header-info p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.profile-chip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.profile-chip .avatar {
+  background: var(--color-primary);
+  color: #ffffff;
+  width: 32px;
+  height: 32px;
+  font-size: 0.9rem;
+}
+
+.content-area {
+  padding: 32px;
+  flex: 1;
+}
+
+.sidebar-backdrop {
+  display: none;
+}
+
+@media (max-width: 1200px) {
+  .main-content {
+    margin-left: var(--sidebar-width);
+  }
+}
+
+@media (max-width: 1024px) {
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    transform: translateX(-100%);
+    width: min(80vw, 300px);
+    border-radius: 0;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .main-content {
+    margin-left: 0;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(2px);
+    z-index: 20;
+  }
+}
+
+@media (max-width: 768px) {
+  .header {
+    padding: 18px 20px;
+  }
+
+  .header-info h1 {
+    font-size: 1.35rem;
+  }
+
+  .content-area {
+    padding: 24px 20px;
+  }
+
+  .profile-chip {
+    display: none;
+  }
+}
+
+@media (max-width: 600px) {
+  .sidebar {
+    width: min(85vw, 280px);
+    padding: 28px 20px;
+  }
+
+  .nav-item {
+    padding: 12px 14px;
+  }
+
+  .logout-button {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add the shared design stylesheet to the frontend bundle and load it globally
- refactor the dashboard layout to use the new sidebar, header, and content structure with design-system classes
- wire up a mobile navigation toggle so the sidebar can open and close on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc427b0158832f8a633f36d347d8f4