### PR TITLE
Refactor managers to use prototype layouts

### DIFF
--- a/frontend/src/AccountManager.module.css
+++ b/frontend/src/AccountManager.module.css
@@ -71,6 +71,22 @@
   gap: 15px;
 }
 
+.accountDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.accountName {
+  font-weight: 600;
+  color: #f5f5f5;
+}
+
+.accountPlatform {
+  font-size: 0.85rem;
+  color: #a8b0bc;
+}
+
 .platform {
   padding: 5px 12px;
   border-radius: 15px;
@@ -87,6 +103,12 @@
   color: #ff6b6b;
 }
 
+.emptyState {
+  color: #a8b0bc;
+  font-style: italic;
+  padding: 15px 0;
+}
+
 /* --- NEW STYLES FOR BUTTONS AND MODAL --- */
 
 .accountActions {
@@ -101,6 +123,39 @@
   font-weight: bold;
   cursor: pointer;
   font-size: 14px;
+}
+
+.accountMeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.timestamp {
+  font-size: 12px;
+  color: #8c939f;
+}
+
+.statusChip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 14px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.statusActive {
+  background-color: #3fa97c;
+  color: #0d271d;
+}
+
+.statusInactive {
+  background-color: #555b65;
+  color: #f1f1f1;
 }
 
 .editButton {
@@ -171,4 +226,9 @@
 .modalActions .cancelButton {
   background-color: #555;
   color: white;
+}
+
+.modalActions .saveButton {
+  background-color: #61dafb;
+  color: #282c34;
 }

--- a/frontend/src/BrandVoiceManager.jsx
+++ b/frontend/src/BrandVoiceManager.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import api from './api.js';
+import styles from './BrandVoiceManager.module.css';
 
 function BrandVoiceManager({ user }) {
   const [voices, setVoices] = useState([]);
@@ -88,169 +89,178 @@ function BrandVoiceManager({ user }) {
     }
   };
 
+  const formatDate = (value) => {
+    if (!value) return '';
+    try {
+      return new Date(value).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch (err) {
+      console.error('Failed to parse date', err);
+      return '';
+    }
+  };
+
   if (isLoading) {
-    return (
-      <div className="flex justify-center py-20">
-        <div className="text-lg font-medium text-gray-500">Loading Source Content...</div>
-      </div>
-    );
+    return <div className={styles.loading}>Loading source content...</div>;
   }
 
   if (error) {
-    return (
-      <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-red-700">
-        {error}
-      </div>
-    );
+    return <div className={styles.errorBanner}>{error}</div>;
   }
 
-  const inputClasses =
-    'w-full rounded-lg border border-gray-300 px-4 py-3 text-gray-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500';
-
   return (
-    <div className="space-y-8">
-      <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
-        <h3 className="mb-6 text-xl font-semibold text-gray-900">Add New Source Content</h3>
-        <form onSubmit={handleCreateVoice} className="space-y-6">
-          <div className="space-y-6">
-            <div className="space-y-2">
-              <label htmlFor="voiceName" className="block text-sm font-medium text-gray-700">
-                Content Title
-              </label>
-              <input
-                id="voiceName"
-                type="text"
-                placeholder="e.g., 'Just Listed - 123 Main St'"
-                value={newVoiceName}
-                onChange={(e) => setNewVoiceName(e.target.value)}
-                className={inputClasses}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <label htmlFor="voiceDesc" className="block text-sm font-medium text-gray-700">
-                Short Description
-              </label>
-              <input
-                id="voiceDesc"
-                type="text"
-                placeholder="e.g., 'Successful post from May 2024'"
-                value={newVoiceDesc}
-                onChange={(e) => setNewVoiceDesc(e.target.value)}
-                className={inputClasses}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <label htmlFor="postExample" className="block text-sm font-medium text-gray-700">
-                Full Post Content
-              </label>
-              <textarea
-                id="postExample"
-                placeholder="Paste the full content of your successful post here..."
-                value={newPostExample}
-                onChange={(e) => setNewPostExample(e.target.value)}
-                className={`${inputClasses} min-h-[200px] resize-y`}
-                required
-                rows="8"
-              />
-            </div>
+    <div className={styles.container}>
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div>
+            <h3 className={styles.cardTitle}>Add New Source Content</h3>
+            <p className={styles.cardSubtitle}>
+              Curate your top-performing posts to train the AI brand voice engine.
+            </p>
           </div>
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              className="inline-flex items-center justify-center rounded-lg bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-            >
+        </div>
+        <form onSubmit={handleCreateVoice} className={styles.formGrid}>
+          <label htmlFor="voiceName" className={styles.label}>
+            Content Title
+            <input
+              id="voiceName"
+              type="text"
+              value={newVoiceName}
+              onChange={(e) => setNewVoiceName(e.target.value)}
+              placeholder="e.g., Luxury waterfront open house"
+              className={styles.input}
+              required
+            />
+          </label>
+          <label htmlFor="voiceDesc" className={styles.label}>
+            Short Description
+            <input
+              id="voiceDesc"
+              type="text"
+              value={newVoiceDesc}
+              onChange={(e) => setNewVoiceDesc(e.target.value)}
+              placeholder="What makes this content special?"
+              className={styles.input}
+              required
+            />
+          </label>
+          <label htmlFor="postExample" className={`${styles.label} ${styles.fullWidth}`}>
+            Full Post Content
+            <textarea
+              id="postExample"
+              value={newPostExample}
+              onChange={(e) => setNewPostExample(e.target.value)}
+              placeholder="Paste the full copy of the post you loved..."
+              className={styles.textarea}
+              required
+              rows="8"
+            />
+            <span className={styles.helperText}>Include emojis, formatting, and hashtags for the best training results.</span>
+          </label>
+          <div className={`${styles.cardActions} ${styles.fullWidth}`}>
+            <button type="submit" className={styles.primaryButton}>
               Add Content
             </button>
           </div>
         </form>
-      </div>
+      </section>
 
-      <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
-        <h3 className="mb-6 text-xl font-semibold text-gray-900">Upload Previous Posts in Bulk</h3>
-        <form onSubmit={handleUploadExamples} className="space-y-6">
-          <div className="space-y-6">
-            <div className="space-y-2">
-              <label htmlFor="voiceSelect" className="block text-sm font-medium text-gray-700">
-                Select Voice
-              </label>
-              <select
-                id="voiceSelect"
-                value={selectedVoiceId}
-                onChange={(e) => setSelectedVoiceId(e.target.value)}
-                className={`${inputClasses} bg-white`}
-                required
-              >
-                <option value="" disabled>
-                  Select a voice
-                </option>
-                {voices.map((v) => (
-                  <option key={v.id} value={v.id}>
-                    {v.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-2">
-              <label htmlFor="bulkExamples" className="block text-sm font-medium text-gray-700">
-                Posts (separate with blank lines)
-              </label>
-              <textarea
-                id="bulkExamples"
-                rows="6"
-                placeholder="Paste multiple posts here..."
-                value={bulkExamples}
-                onChange={(e) => setBulkExamples(e.target.value)}
-                className={`${inputClasses} min-h-[160px] resize-y`}
-                required
-              />
-            </div>
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div>
+            <h3 className={styles.cardTitle}>Upload Previous Posts in Bulk</h3>
+            <p className={styles.cardSubtitle}>
+              Paste multiple winning posts to fast-track your training dataset.
+            </p>
           </div>
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              className="inline-flex items-center justify-center rounded-lg bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+        </div>
+        <form onSubmit={handleUploadExamples} className={styles.formGrid}>
+          <label htmlFor="voiceSelect" className={styles.label}>
+            Select Source Content
+            <select
+              id="voiceSelect"
+              value={selectedVoiceId}
+              onChange={(e) => setSelectedVoiceId(e.target.value)}
+              className={styles.select}
+              required
             >
+              <option value="" disabled>
+                Choose a saved voice
+              </option>
+              {voices.map((voice) => (
+                <option key={voice.id} value={voice.id}>
+                  {voice.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label htmlFor="bulkExamples" className={`${styles.label} ${styles.fullWidth}`}>
+            Posts (separate with blank lines)
+            <textarea
+              id="bulkExamples"
+              value={bulkExamples}
+              onChange={(e) => setBulkExamples(e.target.value)}
+              placeholder="Paste each post on its own with a blank line between"
+              className={styles.textarea}
+              rows="6"
+              required
+            />
+            <span className={styles.helperText}>
+              We’ll split on blank lines so you can paste entire batches from your archives.
+            </span>
+          </label>
+          <div className={`${styles.cardActions} ${styles.fullWidth}`}>
+            <button type="submit" className={styles.secondaryButton}>
               Upload Posts
             </button>
           </div>
         </form>
-      </div>
+      </section>
 
-      <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
-        <h3 className="mb-6 text-xl font-semibold text-gray-900">Your Source Content Library</h3>
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <div>
+            <h3 className={styles.cardTitle}>Source Content Library</h3>
+            <p className={styles.cardSubtitle}>
+              Review and manage the reference posts that power your automations.
+            </p>
+          </div>
+        </div>
         {voices.length > 0 ? (
-          <ul className="space-y-6">
+          <ul className={styles.libraryList}>
             {voices.map((voice) => (
-              <li
-                key={voice.id}
-                className="flex flex-col gap-4 rounded-lg border border-gray-200 p-6 md:flex-row md:items-start md:justify-between"
-              >
-                <div className="flex-1">
-                  <strong className="block text-lg font-semibold text-gray-900">{voice.name}</strong>
-                  <p className="mt-2 text-gray-600">{voice.description}</p>
-                  <pre className="mt-4 whitespace-pre-wrap break-words rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm leading-relaxed text-gray-800">
-                    {voice.post_example}
-                  </pre>
+              <li key={voice.id} className={styles.libraryItem}>
+                <div className={styles.voiceHeader}>
+                  <h4 className={styles.voiceName}>{voice.name}</h4>
+                  <span className={`${styles.statusChip} ${styles.statusReady}`}>Ready</span>
                 </div>
-                <div className="flex items-start md:flex-col md:items-end">
-                  <button
-                    onClick={() => handleDeleteVoice(voice.id)}
-                    className="inline-flex items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-                  >
-                    Delete
-                  </button>
+                <p className={styles.voiceDescription}>{voice.description}</p>
+                <div className={styles.postExample}>
+                  <span className={styles.postLabel}>Example Post</span>
+                  <p className={styles.postBody}>{voice.post_example}</p>
+                </div>
+                <div className={styles.libraryMeta}>
+                  <span className={styles.timestamp}>
+                    {voice.created_at ? `Added ${formatDate(voice.created_at)}` : 'Creation date unavailable'}
+                  </span>
+                  <div className={styles.libraryActions}>
+                    <button type="button" onClick={() => handleDeleteVoice(voice.id)} className={styles.dangerButton}>
+                      Delete
+                    </button>
+                  </div>
                 </div>
               </li>
             ))}
           </ul>
         ) : (
-          <p className="text-gray-600">
-            You haven't added any source content yet. Use the form above to get started.
+          <p className={styles.emptyState}>
+            You haven&apos;t added any source content yet. Capture a post above to get started.
           </p>
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/BrandVoiceManager.module.css
+++ b/frontend/src/BrandVoiceManager.module.css
@@ -1,0 +1,262 @@
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px;
+  color: #e0e0e0;
+}
+
+.card {
+  background-color: #2d3139;
+  border-radius: 10px;
+  padding: 24px 28px;
+  margin-bottom: 30px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.cardTitle {
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.35rem;
+}
+
+.cardSubtitle {
+  margin: 6px 0 0;
+  color: #a8b0bc;
+  font-size: 0.95rem;
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.fullWidth {
+  grid-column: 1 / -1;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: #c7ccd6;
+}
+
+.input,
+.textarea,
+.select {
+  background-color: #3a3f47;
+  border: 1px solid #555b65;
+  border-radius: 6px;
+  color: #f5f5f5;
+  padding: 12px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.textarea {
+  min-height: 200px;
+  resize: vertical;
+}
+
+.helperText {
+  color: #7f8898;
+  font-size: 0.75rem;
+}
+
+.cardActions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+  gap: 12px;
+}
+
+.primaryButton,
+.secondaryButton,
+.dangerButton {
+  border: none;
+  border-radius: 6px;
+  padding: 12px 22px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primaryButton {
+  background-color: #61dafb;
+  color: #1a1d23;
+}
+
+.secondaryButton {
+  background-color: #454b55;
+  color: #ffffff;
+}
+
+.dangerButton {
+  background-color: #f05454;
+  color: #ffffff;
+}
+
+.primaryButton:hover,
+.secondaryButton:hover,
+.dangerButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+}
+
+.libraryList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.libraryItem {
+  background-color: #252932;
+  border-radius: 10px;
+  border: 1px solid #3a3f47;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.voiceHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.voiceName {
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.1rem;
+}
+
+.statusChip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 14px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.statusReady {
+  background-color: #3fa97c;
+  color: #0d271d;
+}
+
+.voiceDescription {
+  margin: 0;
+  color: #c7ccd6;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.postExample {
+  background-color: #1f2229;
+  border-radius: 8px;
+  border: 1px solid #3a3f47;
+  padding: 18px;
+}
+
+.postLabel {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #7f8898;
+  margin-bottom: 10px;
+}
+
+.postBody {
+  margin: 0;
+  color: #f1f3f7;
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+.libraryMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: #8c939f;
+}
+
+.libraryActions {
+  display: flex;
+  gap: 10px;
+}
+
+.emptyState {
+  color: #9aa4b4;
+  font-style: italic;
+  padding: 10px 0;
+}
+
+.loading,
+.errorBanner {
+  text-align: center;
+  padding: 40px;
+  border-radius: 10px;
+}
+
+.loading {
+  color: #9aa4b4;
+}
+
+.errorBanner {
+  background-color: rgba(255, 107, 107, 0.12);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  color: #ff6b6b;
+}
+
+.bulkIntro {
+  margin-top: 6px;
+  color: #9aa4b4;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 20px;
+  }
+
+  .formGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .libraryMeta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cardActions {
+    justify-content: stretch;
+  }
+
+  .cardActions button {
+    width: 100%;
+  }
+}

--- a/frontend/src/SeoTools.jsx
+++ b/frontend/src/SeoTools.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import api from './api.js';
 import { useKeywordSets } from './KeywordSetsContext.jsx';
+import styles from './SeoTools.module.css';
 
 function SeoTools({
   initialSavedBundles,
@@ -199,232 +200,208 @@ function SeoTools({
   };
 
   return (
-    <div className="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow-md space-y-6">
-      <h2 className="text-2xl font-bold">SEO Keyword Analyzer</h2>
-      {error && <div className="text-red-600">{error}</div>}
-      {statusMessage && <div className="text-green-600">{statusMessage}</div>}
+    <div className={styles.container}>
+      <h2 className={styles.title}>SEO Keyword Analyzer</h2>
+      {error && <div className={`${styles.message} ${styles.error}`}>{error}</div>}
+      {statusMessage && <div className={`${styles.message} ${styles.status}`}>{statusMessage}</div>}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="space-y-4">
-          <input
-            type="text"
-            value={keywordInput}
-            onChange={(e) => setKeywordInput(e.target.value)}
-            placeholder="Enter keywords separated by commas"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md"
-          />
-          <input
-            type="text"
-            value={hashtagInput}
-            onChange={(e) => setHashtagInput(e.target.value)}
-            placeholder="Optional hashtags (comma separated)"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md"
-          />
-          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-3 space-y-3 sm:space-y-0">
-            <input
-              type="text"
-              value={keywordSetName}
-              onChange={(e) => setKeywordSetName(e.target.value)}
-              placeholder="Name this keyword set"
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md"
-            />
-            <button
-              type="button"
-              onClick={handleSaveKeywordSet}
-              className="px-4 py-2 font-semibold text-white bg-green-600 rounded-md hover:bg-green-700"
-            >
-              Save for Social Media
-            </button>
+      <div className={styles.grid}>
+        <section className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h3 className={styles.cardTitle}>Discover High-Impact Keywords</h3>
+            <p className={styles.cardSubtitle}>
+              Run analysis on your seed keywords, capture hashtags, and save bundles for later.
+            </p>
           </div>
-          <button
-            type="button"
-            onClick={handleAnalyze}
-            className="px-4 py-2 font-semibold text-white bg-blue-600 rounded-md hover:bg-blue-700"
-          >
-            Analyze
-          </button>
-          {saveMessage && <div className="text-green-600 text-sm">{saveMessage}</div>}
-        </div>
+          <div className={styles.inputGrid}>
+            <div className={styles.inputGroup}>
+              <label htmlFor="keywordInput">Keywords</label>
+              <input
+                id="keywordInput"
+                type="text"
+                value={keywordInput}
+                onChange={(e) => setKeywordInput(e.target.value)}
+                placeholder="Enter keywords separated by commas"
+                className={styles.textInput}
+              />
+            </div>
+            <div className={styles.inputGroup}>
+              <label htmlFor="hashtagInput">Optional Hashtags</label>
+              <input
+                id="hashtagInput"
+                type="text"
+                value={hashtagInput}
+                onChange={(e) => setHashtagInput(e.target.value)}
+                placeholder="Comma-separated hashtags"
+                className={styles.textInput}
+              />
+            </div>
+            <div className={styles.inputGroup}>
+              <label htmlFor="keywordSetName">Name this keyword set</label>
+              <div className={styles.buttonRow}>
+                <input
+                  id="keywordSetName"
+                  type="text"
+                  value={keywordSetName}
+                  onChange={(e) => setKeywordSetName(e.target.value)}
+                  placeholder="e.g., Spring Listings Push"
+                  className={styles.textInput}
+                />
+                <button type="button" onClick={handleSaveKeywordSet} className={styles.secondaryButton}>
+                  Save for Social Media
+                </button>
+              </div>
+              {saveMessage && <span className={styles.savedMessage}>{saveMessage}</span>}
+            </div>
+            <div className={styles.actionRow}>
+              <button type="button" onClick={handleAnalyze} className={styles.primaryButton}>
+                Analyze Keywords
+              </button>
+            </div>
+          </div>
+        </section>
 
-        <div className="bg-gray-50 border rounded-lg p-4 space-y-3">
-          <h3 className="text-lg font-semibold">Saved Keyword Sets</h3>
-          {savedKeywordSets.length === 0 ? (
-            <p className="text-sm text-gray-600">No keyword sets saved yet.</p>
-          ) : (
-            <ul className="space-y-3 max-h-64 overflow-y-auto">
-              {savedKeywordSets.map((set) => (
-                <li key={set.id} className="p-3 bg-white border rounded-md">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <p className="font-semibold">{set.name}</p>
-                      <p className="text-sm text-gray-600">Primary: {set.primaryKeyword}</p>
-                      {set.hashtags?.length > 0 && (
-                        <p className="text-xs text-gray-500">Hashtags: {set.hashtags.join(', ')}</p>
-                      )}
-                      {set.keywords?.length > 0 && (
-                        <p className="text-xs text-gray-500">Keywords: {set.keywords.join(', ')}</p>
-                      )}
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveSet(set.id)}
-                      className="text-sm text-red-600 hover:text-red-800"
-                    >
+        <aside className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h3 className={styles.cardTitle}>Saved Keyword Sets</h3>
+            <p className={styles.cardSubtitle}>Quickly reuse sets in the Social Media Manager.</p>
+          </div>
+          <div className={styles.keywordSetsCard}>
+            {savedKeywordSets.length === 0 ? (
+              <p className={styles.emptyState}>No keyword sets saved yet.</p>
+            ) : (
+              savedKeywordSets.map((set) => (
+                <div key={set.id} className={styles.keywordSetItem}>
+                  <div className={styles.keywordSetMeta}>
+                    <p>{set.name}</p>
+                    {set.primaryKeyword && <span>Primary: {set.primaryKeyword}</span>}
+                    {set.hashtags?.length > 0 && <span>Hashtags: {set.hashtags.join(', ')}</span>}
+                    {set.keywords?.length > 0 && <span>Keywords: {set.keywords.join(', ')}</span>}
+                  </div>
+                  <div className={styles.keywordSetActions}>
+                    <button type="button" className={styles.linkButton} onClick={() => handleRemoveSet(set.id)}>
                       Remove
                     </button>
                   </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+                </div>
+              ))
+            )}
+          </div>
+        </aside>
       </div>
 
       {analysis && (
-        <div className="space-y-6">
+        <section className={styles.resultsCard}>
           <div>
-            <h3 className="font-semibold">Normalized Keywords</h3>
-            <p className="text-sm text-gray-700">{(analysis.input || []).join(', ')}</p>
+            <h3 className={styles.sectionTitle}>Normalized Keywords</h3>
+            <p className={styles.sectionText}>{(analysis.input || []).join(', ')}</p>
           </div>
+
           <div>
-            <h3 className="font-semibold">Suggestions</h3>
+            <h3 className={styles.sectionTitle}>Suggestions</h3>
             {(analysis.suggestions || []).length > 0 ? (
-              <div className="space-y-3">
-                <div className="flex flex-wrap gap-2">
+              <>
+                <div className={styles.chipList}>
                   {analysis.suggestions.map((suggestion, idx) => {
                     const isSelected = selectedKeywords.includes(suggestion);
                     return (
-                      <div key={`${suggestion}-${idx}`} className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => toggleKeyword(suggestion)}
-                          className={`px-3 py-1 rounded-full border text-sm transition-colors ${
-                            isSelected
-                              ? 'bg-blue-100 border-blue-500 text-blue-700'
-                              : 'bg-gray-100 border-gray-300 text-gray-700 hover:bg-gray-200'
-                          }`}
-                        >
-                          {suggestion}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleCopyKeywords(suggestion)}
-                          className="text-xs font-medium text-blue-600 hover:underline"
-                        >
-                          Copy
-                        </button>
+                      <div key={`${suggestion}-${idx}`} className={`${styles.chip} ${isSelected ? styles.chipActive : ''}`}>
+                        <span>{suggestion}</span>
+                        <div className={styles.chipActions}>
+                          <button type="button" className={styles.linkButton} onClick={() => toggleKeyword(suggestion)}>
+                            {isSelected ? 'Remove' : 'Select'}
+                          </button>
+                          <button type="button" className={styles.linkButton} onClick={() => handleCopyKeywords(suggestion)}>
+                            Copy
+                          </button>
+                        </div>
                       </div>
                     );
                   })}
                 </div>
-                <div className="flex flex-wrap gap-2">
+                <div className={styles.actionRow}>
                   <button
                     type="button"
                     onClick={() => handleCopyKeywords(analysis.suggestions)}
-                    className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-100"
+                    className={styles.secondaryButton}
                   >
                     Copy All Suggestions
                   </button>
-                  <button
-                    type="button"
-                    onClick={handleSelectAllSuggestions}
-                    className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-100"
-                  >
+                  <button type="button" onClick={handleSelectAllSuggestions} className={styles.secondaryButton}>
                     Select All Suggestions
                   </button>
                 </div>
-              </div>
+              </>
             ) : (
-              <p>No suggestions available.</p>
+              <p className={styles.sectionText}>No suggestions available.</p>
             )}
           </div>
+
           <div>
-            <h3 className="font-semibold">Scores</h3>
+            <h3 className={styles.sectionTitle}>Scores</h3>
             {Object.keys(analysis.scores || {}).length > 0 ? (
-              <div className="space-y-3">
-                <div className="space-y-2">
+              <>
+                <div className={styles.inputGrid}>
                   {Object.entries(analysis.scores || {}).map(([kw, score]) => {
                     const isSelected = selectedKeywords.includes(kw);
                     return (
-                      <div
-                        key={kw}
-                        className="flex flex-wrap items-center justify-between gap-2 border border-gray-200 rounded-md px-3 py-2"
-                      >
-                        <div className="flex items-center gap-3">
-                          <button
-                            type="button"
-                            onClick={() => toggleKeyword(kw)}
-                            className={`px-3 py-1 rounded-full border text-sm transition-colors ${
-                              isSelected
-                                ? 'bg-blue-100 border-blue-500 text-blue-700'
-                                : 'bg-gray-100 border-gray-300 text-gray-700 hover:bg-gray-200'
-                            }`}
-                          >
-                            {kw}
-                          </button>
-                          <span className="text-sm text-gray-600">Score: {score}</span>
+                      <div key={kw} className={styles.scoreRow}>
+                        <div className={styles.chipActions}>
+                          <div className={`${styles.chip} ${isSelected ? styles.chipActive : ''}`}>
+                            <span>{kw}</span>
+                            <button type="button" className={styles.linkButton} onClick={() => toggleKeyword(kw)}>
+                              {isSelected ? 'Remove' : 'Select'}
+                            </button>
+                          </div>
                         </div>
-                        <button
-                          type="button"
-                          onClick={() => handleCopyKeywords(kw)}
-                          className="text-xs font-medium text-blue-600 hover:underline"
-                        >
+                        <span>Score: {score}</span>
+                        <button type="button" className={styles.linkButton} onClick={() => handleCopyKeywords(kw)}>
                           Copy
                         </button>
                       </div>
                     );
                   })}
                 </div>
-                <div className="flex flex-wrap gap-2">
+                <div className={styles.actionRow}>
                   <button
                     type="button"
                     onClick={() => handleCopyKeywords(Object.keys(analysis.scores || {}))}
-                    className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-100"
+                    className={styles.secondaryButton}
                   >
                     Copy All Score Keywords
                   </button>
-                  <button
-                    type="button"
-                    onClick={handleSelectAllScoreKeywords}
-                    className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-100"
-                  >
+                  <button type="button" onClick={handleSelectAllScoreKeywords} className={styles.secondaryButton}>
                     Select All Score Keywords
                   </button>
                 </div>
-              </div>
+              </>
             ) : (
-              <p>No scores available.</p>
+              <p className={styles.sectionText}>No scores available.</p>
             )}
           </div>
+
           <div>
-            <h3 className="font-semibold">Selected Keywords</h3>
+            <h3 className={styles.sectionTitle}>Selected Keywords</h3>
             {selectedKeywords.length > 0 ? (
-              <div className="mt-2 flex flex-wrap gap-2">
+              <div className={styles.selectedChips}>
                 {selectedKeywords.map((keyword) => (
-                  <span
-                    key={keyword}
-                    className="inline-flex items-center gap-2 px-3 py-1 text-sm rounded-full bg-blue-100 text-blue-700"
-                  >
-                    {keyword}
-                    <button
-                      type="button"
-                      onClick={() => toggleKeyword(keyword)}
-                      className="text-xs font-semibold text-blue-600 hover:underline"
-                    >
+                  <div key={keyword} className={`${styles.chip} ${styles.chipActive}`}>
+                    <span>{keyword}</span>
+                    <button type="button" className={styles.linkButton} onClick={() => toggleKeyword(keyword)}>
                       Remove
                     </button>
-                  </span>
+                  </div>
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-gray-500">No keywords selected yet.</p>
+              <p className={styles.sectionText}>No keywords selected yet.</p>
             )}
-            <div className="mt-3 flex flex-wrap gap-2">
+            <div className={styles.actionRow}>
               <button
                 type="button"
                 onClick={() => handleCopyKeywords(selectedKeywords)}
                 disabled={selectedKeywords.length === 0}
-                className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100"
+                className={styles.secondaryButton}
               >
                 Copy Selected Keywords
               </button>
@@ -432,70 +409,62 @@ function SeoTools({
                 type="button"
                 onClick={handleClearSelected}
                 disabled={selectedKeywords.length === 0}
-                className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100"
+                className={styles.secondaryButton}
               >
                 Clear Selection
               </button>
             </div>
-            <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <div className={styles.buttonRow}>
               <input
                 type="text"
                 value={bundleName}
                 onChange={(e) => setBundleName(e.target.value)}
                 placeholder="Name this bundle"
-                className="w-full sm:flex-1 px-3 py-2 border border-gray-300 rounded-md"
+                className={styles.textInput}
               />
               <button
                 type="button"
                 onClick={handleSaveBundle}
                 disabled={selectedKeywords.length === 0}
-                className="px-4 py-2 text-sm font-semibold text-white bg-green-600 rounded-md disabled:opacity-50 disabled:cursor-not-allowed hover:bg-green-700"
+                className={styles.primaryButton}
               >
                 Save Selected Keywords
               </button>
             </div>
           </div>
-        </div>
+        </section>
       )}
 
-      <div className="space-y-3">
-        <h3 className="font-semibold">Saved Keyword Bundles</h3>
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <h3 className={styles.cardTitle}>Saved Keyword Bundles</h3>
+          <p className={styles.cardSubtitle}>Reuse curated collections without starting from scratch.</p>
+        </div>
         {savedBundles.length > 0 ? (
-          <ul className="space-y-3">
+          <ul className={styles.bundleList}>
             {savedBundles.map((bundle) => (
-              <li key={bundle.id} className="border border-gray-200 rounded-md p-3">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="font-medium">{bundle.name}</p>
-                    <p className="text-sm text-gray-600 break-words">{bundle.keywords.join(', ')}</p>
-                  </div>
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => handleCopyKeywords(bundle.keywords)}
-                      className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-100"
-                    >
-                      Copy
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleLoadBundle(bundle)}
-                      className="px-3 py-1 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-100"
-                    >
-                      Load
-                    </button>
-                  </div>
+              <li key={bundle.id} className={styles.bundleItem}>
+                <div className={styles.bundleMeta}>
+                  <p>{bundle.name}</p>
+                  <span>{bundle.keywords.join(', ')}</span>
+                </div>
+                <div className={styles.bundleActions}>
+                  <button type="button" onClick={() => handleCopyKeywords(bundle.keywords)} className={styles.secondaryButton}>
+                    Copy
+                  </button>
+                  <button type="button" onClick={() => handleLoadBundle(bundle)} className={styles.primaryButton}>
+                    Load
+                  </button>
                 </div>
               </li>
             ))}
           </ul>
         ) : (
-          <p className="text-sm text-gray-500">No saved bundles yet. Save selections to reuse them later.</p>
+          <p className={styles.emptyState}>No saved bundles yet. Save selections to reuse them later.</p>
         )}
-      </div>
+      </section>
     </div>
   );
 }
 
 export default SeoTools;
-

--- a/frontend/src/SeoTools.module.css
+++ b/frontend/src/SeoTools.module.css
@@ -1,0 +1,327 @@
+.container {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 20px;
+  color: #e0e0e0;
+}
+
+.title {
+  margin: 0 0 20px;
+  font-size: 1.8rem;
+  color: #ffffff;
+}
+
+.message {
+  margin-bottom: 16px;
+  padding: 14px 18px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.error {
+  background-color: rgba(255, 107, 107, 0.12);
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  color: #ff8181;
+}
+
+.status {
+  background-color: rgba(97, 218, 251, 0.12);
+  border: 1px solid rgba(97, 218, 251, 0.35);
+  color: #61dafb;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.card {
+  background-color: #2d3139;
+  border-radius: 10px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.cardHeader {
+  margin-bottom: 18px;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #ffffff;
+}
+
+.cardSubtitle {
+  margin: 6px 0 0;
+  color: #9aa4b4;
+  font-size: 0.9rem;
+}
+
+.inputGrid {
+  display: grid;
+  gap: 18px;
+}
+
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #c7ccd6;
+  font-size: 0.85rem;
+}
+
+.textInput,
+.textArea,
+.select {
+  background-color: #3a3f47;
+  border: 1px solid #555b65;
+  border-radius: 6px;
+  padding: 12px;
+  color: #f5f5f5;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.textArea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.buttonRow,
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.primaryButton,
+.secondaryButton,
+.dangerButton {
+  border: none;
+  border-radius: 6px;
+  padding: 12px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primaryButton {
+  background-color: #61dafb;
+  color: #1a1d23;
+}
+
+.secondaryButton {
+  background-color: #454b55;
+  color: #ffffff;
+}
+
+.dangerButton {
+  background-color: #f05454;
+  color: #ffffff;
+}
+
+.primaryButton:hover,
+.secondaryButton:hover,
+.dangerButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+}
+
+.linkButton {
+  background: none;
+  border: none;
+  color: #61dafb;
+  cursor: pointer;
+  padding: 0;
+  font-weight: 600;
+}
+
+.chipList,
+.selectedChips,
+.chipActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chip {
+  background-color: #252932;
+  border: 1px solid #3a3f47;
+  border-radius: 20px;
+  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: #d8dde6;
+}
+
+.chipActive {
+  background-color: rgba(97, 218, 251, 0.18);
+  border-color: rgba(97, 218, 251, 0.45);
+  color: #61dafb;
+}
+
+.resultsCard {
+  background-color: #2d3139;
+  border-radius: 10px;
+  padding: 24px;
+  display: grid;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.sectionTitle {
+  margin: 0 0 12px;
+  color: #ffffff;
+  font-size: 1.05rem;
+}
+
+.sectionText {
+  margin: 0;
+  color: #c7ccd6;
+  font-size: 0.95rem;
+}
+
+.scoreRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid #3a3f47;
+  border-radius: 8px;
+  background-color: #252932;
+}
+
+.scoreRow span {
+  color: #9aa4b4;
+  font-size: 0.85rem;
+}
+
+.selectedChips .chip {
+  background-color: rgba(97, 218, 251, 0.15);
+  border-color: rgba(97, 218, 251, 0.45);
+  color: #61dafb;
+}
+
+.bundleList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.bundleItem {
+  background-color: #252932;
+  border: 1px solid #3a3f47;
+  border-radius: 8px;
+  padding: 18px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.bundleMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bundleMeta p {
+  margin: 0;
+  color: #d8dde6;
+  font-size: 0.9rem;
+}
+
+.bundleMeta span {
+  color: #9aa4b4;
+  font-size: 0.8rem;
+}
+
+.bundleActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.emptyState {
+  color: #9aa4b4;
+  font-style: italic;
+}
+
+.keywordSetsCard {
+  background-color: #252932;
+  border-radius: 8px;
+  border: 1px solid #3a3f47;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.keywordSetItem {
+  border: 1px solid #3a3f47;
+  border-radius: 8px;
+  padding: 14px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  background-color: #1f2229;
+}
+
+.keywordSetMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.keywordSetMeta p {
+  margin: 0;
+  color: #d8dde6;
+  font-size: 0.85rem;
+}
+
+.keywordSetMeta span {
+  color: #9aa4b4;
+  font-size: 0.75rem;
+}
+
+.keywordSetActions {
+  display: flex;
+  align-items: center;
+}
+
+.savedMessage {
+  color: #61dafb;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bundleItem,
+  .keywordSetItem {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .bundleActions {
+    width: 100%;
+  }
+}

--- a/frontend/src/SocialMediaManager.module.css
+++ b/frontend/src/SocialMediaManager.module.css
@@ -1,85 +1,142 @@
-/* frontend/src/SocialMediaManager.module.css - FULL REPLACEMENT */
-
 .manager {
-  max-width: 900px;
+  max-width: 1180px;
   margin: 0 auto;
   padding: 20px;
+  color: #e0e0e0;
 }
 
-.loading, .error {
+.loading,
+.error {
   text-align: center;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   padding: 40px;
-  color: #999;
 }
+
 .error {
   color: #ff6b6b;
   background-color: rgba(255, 107, 107, 0.1);
-  border: 1px solid #ff6b6b;
-  border-radius: 5px;
-  padding: 15px;
+  border: 1px solid rgba(255, 107, 107, 0.35);
+  border-radius: 6px;
   margin-bottom: 20px;
 }
 
-.formCard, .listCard {
+.warning {
+  color: #f7c66a;
+  background-color: rgba(247, 198, 106, 0.12);
+  border: 1px solid rgba(247, 198, 106, 0.35);
+  border-radius: 6px;
+  padding: 14px 16px;
+  margin-bottom: 20px;
+  font-size: 0.95rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+
+@media (min-width: 992px) {
+  .layout {
+    grid-template-columns: 360px 1fr;
+    align-items: start;
+  }
+}
+
+.formCard,
+.listCard {
   background-color: #2d3139;
   padding: 25px;
-  border-radius: 8px;
-  margin-bottom: 30px;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
 }
 
-.formCard h3, .listCard h3 {
+.formCard h3,
+.listCard h3 {
   margin-top: 0;
-  border-bottom: 1px solid #444;
-  padding-bottom: 15px;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
+  color: #ffffff;
+  font-size: 1.2rem;
 }
 
-.formCard form {
+.postForm {
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  margin-top: 20px; /* Add space below AI section */
+  gap: 18px;
+  margin-top: 24px;
 }
 
-/* --- NEW: AI Generator Section Styles --- */
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: #c7ccd6;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+}
+
+.inlineRow {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.inlineRow input {
+  flex: 1 1 220px;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
 .aiSection {
   background-color: #252526;
-  border: 1px solid #444;
+  border: 1px solid #3a3f47;
   border-radius: 8px;
   padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 15px;
 }
+
 .aiSection h4 {
   margin: 0;
   color: #61dafb;
 }
+
 .aiSection button {
   padding: 10px 20px;
   border: none;
-  border-radius: 5px;
+  border-radius: 6px;
   background-color: #61dafb;
-  color: #282c34;
-  font-weight: bold;
+  color: #1a1d23;
+  font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: transform 0.2s ease;
 }
+
 .aiSection button:disabled {
-  background-color: #555;
+  background-color: #4a4f57;
+  color: #9aa4b4;
   cursor: not-allowed;
 }
+
 .aiSection button:hover:not(:disabled) {
-  background-color: #88eaff;
+  transform: translateY(-1px);
 }
 
-
-.formCard input, .formCard textarea, .formCard select {
+.formCard input,
+.formCard textarea,
+.formCard select {
   width: 100%;
   padding: 12px;
-  border-radius: 5px;
-  border: 1px solid #555;
+  border-radius: 6px;
+  border: 1px solid #555b65;
   background-color: #3a3f47;
   color: #e0e0e0;
   font-size: 16px;
@@ -92,28 +149,90 @@
   resize: vertical;
 }
 
-.formCard button[type="submit"] {
-  align-self: flex-end;
-  padding: 12px 25px;
+.primaryButton {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 22px;
+  border-radius: 6px;
   border: none;
-  border-radius: 5px;
-  background-color: #5cb85c;
-  color: white;
-  font-weight: bold;
+  background-color: #61dafb;
+  color: #1a1d23;
+  font-weight: 600;
   cursor: pointer;
-  font-size: 16px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-/* --- NEW: Hashtag Display Styles --- */
+.primaryButton:disabled {
+  background-color: #4a4f57;
+  color: #9aa4b4;
+  cursor: not-allowed;
+}
+
+.primaryButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+}
+
+.secondaryButton {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 18px;
+  border-radius: 6px;
+  border: none;
+  background-color: #454b55;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.15s ease;
+}
+
+.secondaryButton:hover {
+  transform: translateY(-1px);
+  background-color: #525965;
+}
+
+.formActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.seoResult {
+  background-color: #1f2229;
+  border-radius: 8px;
+  border: 1px solid #3a3f47;
+  padding: 16px;
+  font-size: 0.9rem;
+  color: #d8dde6;
+  display: grid;
+  gap: 6px;
+}
+
+.hashtagGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fieldLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #a8b0bc;
+  letter-spacing: 0.4px;
+}
+
 .hashtagContainer {
   display: flex;
-  flex-wrap: wrap; /* This is the key property */
+  flex-wrap: wrap;
   gap: 8px;
   padding: 10px;
   border-radius: 5px;
   background-color: #252526;
   min-height: 40px;
 }
+
 .hashtagItem {
   background-color: #007bff;
   color: white;
@@ -122,27 +241,40 @@
   font-size: 14px;
   white-space: nowrap;
 }
+
 .noHashtags {
   color: #888;
   font-style: italic;
   margin: auto 0;
 }
 
+.listHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.postCount {
+  font-size: 0.85rem;
+  color: #9aa4b4;
+}
 
 .postList {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .postItem {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid #444;
   gap: 20px;
+  padding: 20px 0;
+  border-bottom: 1px solid #3a3f47;
 }
+
 .postItem:last-child {
   border-bottom: none;
 }
@@ -156,20 +288,39 @@
   white-space: pre-wrap;
 }
 
-.postContent small {
-  color: #aaa;
-  text-transform: capitalize;
+.postHashtags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
-.postItem.draft small {
-  color: #f0ad4e;
+.postMeta {
+  font-size: 0.85rem;
+  color: #9aa4b4;
+  margin: 4px 0;
 }
-.postItem.approved small {
-  color: #5cb85c;
+
+.postMeta span {
+  font-weight: 600;
+  color: #d8dde6;
+  margin-right: 6px;
+}
+
+.postSidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  min-width: 180px;
+}
+
+.accountLabel {
+  font-size: 0.8rem;
+  color: #9aa4b4;
 }
 
 .postActions {
-  flex-shrink: 0;
   display: flex;
   gap: 10px;
 }
@@ -177,17 +328,87 @@
 .postActions button {
   padding: 8px 15px;
   border: none;
-  border-radius: 5px;
+  border-radius: 6px;
   cursor: pointer;
   background-color: #5cb85c;
   color: white;
+  font-weight: 600;
 }
 
 .deleteButton {
   background-color: #f44336 !important;
   color: white;
 }
-/* Add these new styles to the VERY END of your existing file */
+
+.statusChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.statusDraft {
+  background-color: rgba(247, 198, 106, 0.2);
+  color: #f7c66a;
+}
+
+.statusScheduled {
+  background-color: rgba(97, 218, 251, 0.2);
+  color: #61dafb;
+}
+
+.statusPublished {
+  background-color: rgba(92, 184, 92, 0.2);
+  color: #7ed58f;
+}
+
+.statusDefault {
+  background-color: rgba(142, 150, 160, 0.2);
+  color: #b5bcc9;
+}
+
+.emptyState {
+  color: #9aa4b4;
+  font-style: italic;
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 50;
+}
+
+.modalContent {
+  background-color: #2d3139;
+  border-radius: 10px;
+  padding: 24px;
+  width: 100%;
+  max-width: 520px;
+  border: 1px solid #3a3f47;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.modalTitle {
+  margin: 0 0 18px 0;
+  color: #ffffff;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 20px;
+}
 
 .savedHashtagContainer {
   display: flex;
@@ -205,3 +426,104 @@
   font-size: 12px;
 }
 
+.keywordModal {
+  background-color: #2d3139;
+  border-radius: 10px;
+  border: 1px solid #3a3f47;
+  padding: 24px;
+  width: 100%;
+  max-width: 640px;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.keywordHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.keywordHeader h3 {
+  margin: 0;
+  color: #ffffff;
+}
+
+.keywordHeader p {
+  margin: 6px 0 0;
+  color: #9aa4b4;
+  font-size: 0.85rem;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: #9aa4b4;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.closeButton:hover {
+  color: #ffffff;
+}
+
+.keywordSetList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.keywordSetCard {
+  background-color: #252932;
+  border-radius: 8px;
+  border: 1px solid #3a3f47;
+  padding: 18px;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.keywordSetMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.keywordSetName {
+  margin: 0;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.keywordSetDetail {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #9aa4b4;
+}
+
+.keywordSetActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+@media (max-width: 720px) {
+  .modalContent,
+  .keywordModal {
+    padding: 20px;
+  }
+
+  .postSidebar {
+    align-items: flex-start;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- replace AccountManager UI with the new dark card/list structure while preserving existing account flows
- rebuild the brand voice, social media, and SEO tool components to follow the new prototype card layouts and state wiring
- add supporting CSS modules for brand voice, social media, and SEO tools styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc4c52a978832fb2e50a2fd9c7ae37