### PR TITLE
Fix sidebar positioning to remain pinned

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -47,7 +47,12 @@ body {
 }
 
 .sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
   width: var(--sidebar-width);
+  height: 100vh;
   background: var(--color-sidebar);
   color: #ffffff;
   display: flex;
@@ -55,7 +60,7 @@ body {
   padding: 32px 24px;
   gap: 32px;
   box-shadow: var(--shadow-soft);
-  position: relative;
+  overflow-y: auto;
   z-index: 30;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
@@ -349,10 +354,6 @@ body {
 
 @media (max-width: 1024px) {
   .sidebar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
     transform: translateX(-100%);
     width: min(80vw, 300px);
     border-radius: 0;


### PR DESCRIPTION
## Summary
- update the base sidebar styles to use fixed positioning with full-height scrolling
- streamline the mobile breakpoint so the slide-in animation continues to work with the fixed sidebar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc547dca8c832f911ff12bf12cef13