### PR TITLE
Handle missing Apify API key gracefully

### DIFF
--- a/frontend/src/stores/propertyStore.js
+++ b/frontend/src/stores/propertyStore.js
@@ -698,6 +698,10 @@ function createPropertyStore() {
         return cached.properties;
       }
 
+      const responseError = safeString(fetchError?.response?.data?.error);
+      const errorMessage =
+        responseError || fetchError?.message || 'Failed to fetch property data. Please try again later.';
+
       setState({
         properties: [],
         statistics: { ...defaultStatistics },
@@ -705,8 +709,7 @@ function createPropertyStore() {
         loading: false,
         lastUpdated: null,
         dataSource: null,
-        error:
-          fetchError?.message ?? 'Failed to fetch property data. Please try again later.',
+        error: errorMessage,
       });
 
       return [];

--- a/src/services/realtor_scraper_service.py
+++ b/src/services/realtor_scraper_service.py
@@ -45,6 +45,10 @@ WINDSOR_ESSEX_CITIES = [
 ]
 
 
+class MissingApifyApiKeyError(RuntimeError):
+    """Raised when the Apify API key is not configured for scraping."""
+
+
 class RealtorScraperService:
     """High-level interface responsible for orchestrating the Realtor.ca scrape."""
 
@@ -64,8 +68,10 @@ class RealtorScraperService:
     ) -> List[Dict[str, Any]]:
         """Scrape Realtor.ca for Windsor-Essex listings via Apify."""
 
-        if not self._apify_token:
-            raise RuntimeError("APIFY_API_KEY is not configured for the scraper service.")
+        if not self.is_configured:
+            raise MissingApifyApiKeyError(
+                "APIFY_API_KEY is not configured for the scraper service."
+            )
 
         client = ApifyClient(self._apify_token)
         run_input = {
@@ -102,6 +108,12 @@ class RealtorScraperService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+    @property
+    def is_configured(self) -> bool:
+        """Return whether the scraper has a configured Apify API token."""
+
+        return bool(self._apify_token)
+
     def _wait_for_dataset_ready(
         self,
         client: ApifyClient,


### PR DESCRIPTION
## Summary
- add an explicit exception and configuration check to the Realtor.ca scraper service
- return a 503 response with a clear JSON error when the Apify key is missing
- surface backend error messages in the property store to guide frontend users

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc5fd18874832f94491e66d75e023d